### PR TITLE
forceRedrawVimView called after exiting full screen

### DIFF
--- a/VimR/TextMate/VRWorkspaceView.m
+++ b/VimR/TextMate/VRWorkspaceView.m
@@ -214,6 +214,8 @@ static const int qMinimumFileBrowserWidth = 100;
   if ([_userDefaults boolForKey:qDefaultShowSideBar]) {
     self.fileBrowserView = _cachedFileBrowserView;
   }
+
+  [[NSNotificationCenter defaultCenter] addObserver:self.mainWindowController selector:@selector(forceRedrawVimView) name:@"NSWindowDidExitFullScreenNotification" object:self.window];
 }
 
 - (void)setStatusMessage:(NSString *)message {


### PR DESCRIPTION
Fixes rendering issue in upper part of vim view after entering full
screen, toggling status bar then exiting full screen
