### PR TITLE
forceRedrawVimView called after exiting full screen

### DIFF
--- a/VimR/TextMate/VRWorkspaceView.m
+++ b/VimR/TextMate/VRWorkspaceView.m
@@ -214,8 +214,6 @@ static const int qMinimumFileBrowserWidth = 100;
   if ([_userDefaults boolForKey:qDefaultShowSideBar]) {
     self.fileBrowserView = _cachedFileBrowserView;
   }
-
-  [[NSNotificationCenter defaultCenter] addObserver:self.mainWindowController selector:@selector(forceRedrawVimView) name:@"NSWindowDidExitFullScreenNotification" object:self.window];
 }
 
 - (void)setStatusMessage:(NSString *)message {

--- a/VimR/VRMainWindowController.m
+++ b/VimR/VRMainWindowController.m
@@ -664,6 +664,10 @@ static NSString *const qMainWindowFrameAutosaveName = @"main-window-frame-autosa
   return NO;
 }
 
+- (void)windowDidExitFullScreen:(NSNotification *)notification {
+    [self forceRedrawVimView];
+}
+
 /**
 * Resize code
 */


### PR DESCRIPTION
Fixes rendering issue in upper part of vim view after entering full
screen, toggling status bar then exiting full screen

My previous pull request for this commit was mistakenly made for the master branch, so recreated for develop branch.
