### PR TITLE
denote utf-8 encoding

### DIFF
--- a/VimR/Resources/vimr
+++ b/VimR/Resources/vimr
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# encoding: utf-8
 
 require 'pathname'
 require 'optparse'


### PR DESCRIPTION
This fixes an issue there the ruby interpreter runs into a syntax error because it can't interpret the unicode symbol for "greater than or equal" for the cli tool:

```
/Users/mrtazz/bin/vimr:17: invalid multibyte char (US-ASCII)
/Users/mrtazz/bin/vimr:14: syntax error, unexpected $end, expecting tSTRING_CONTENT or tSTRING_DBEG or tSTRING_DVAR or tSTRING_END
```
