### PR TITLE
Redraw vim view when moving between retina and non-retina displays

### DIFF
--- a/VimR/VRMainWindowController.m
+++ b/VimR/VRMainWindowController.m
@@ -783,6 +783,10 @@ static NSString *const qMainWindowFrameAutosaveName = @"main-window-frame-autosa
   [self forceRedrawVimView];
 }
 
+- (void)windowDidChangeBackingProperties:(NSNotification *)notification {
+  [self forceRedrawVimView];
+}
+
 /**
 * Resize code
 */


### PR DESCRIPTION
The vim view is cleared but not redrawn when the window backing properties change, i.e. when a window is moved between retina and non-retina displays. This results in a blank white view until the next redraw.

This PR implements the `NSWindowDelegate` `- windowDidChangeBackingProperties:` method to force redraw immediately after the backing properties change.

Fixes #187.