### PR TITLE
Update the scroll bar when scrolling the document. Fixes #191.

### DIFF
--- a/VimR/VRMainWindowController.m
+++ b/VimR/VRMainWindowController.m
@@ -659,7 +659,7 @@ static NSString *const qMainWindowFrameAutosaveName = @"main-window-frame-autosa
 }
 
 - (void)controller:(MMVimController *)controller setScrollbarThumbValue:(float)value proportion:(float)proportion identifier:(int32_t)identifier data:(NSData *)data {
-  DDLogDebug(@"NOOP");
+  [self.vimView setScrollbarThumbValue:value proportion:proportion identifier:identifier];
 }
 
 - (void)controller:(MMVimController *)controller tabDraggedWithData:(NSData *)data {


### PR DESCRIPTION
Plumb `- controller:setScrollbarThumbValue:proportion:identifier:data:`
through to `vimView`.

Note that when you jump to the bottom of the document using `G` the
scrollbar indicator is not positioned at the bottom of the scrollbar.
This is because it is possible to scroll past the bottom of the document
so that the bottom line is at the top of the MMVimView. This behavior is
inherited from MacVim.