### PR TITLE
More vim movements for filebrowser

### DIFF
--- a/VimR/Cocoa Categories/NSTableView+VR.h
+++ b/VimR/Cocoa Categories/NSTableView+VR.h
@@ -15,5 +15,7 @@
 - (void)moveSelectionByDelta:(NSInteger)delta;
 - (void)moveSelectionToBottom;
 - (void)moveSelectionToTop;
+- (void)scrollDownOneLine;
+- (void)scrollUpOneLine;
 
 @end

--- a/VimR/Cocoa Categories/NSTableView+VR.h
+++ b/VimR/Cocoa Categories/NSTableView+VR.h
@@ -17,5 +17,7 @@
 - (void)moveSelectionToTop;
 - (void)scrollDownOneLine;
 - (void)scrollUpOneLine;
+- (void)scrollDownOneScreen;
+- (void)scrollUpOneScreen;
 
 @end

--- a/VimR/Cocoa Categories/NSTableView+VR.h
+++ b/VimR/Cocoa Categories/NSTableView+VR.h
@@ -13,5 +13,7 @@
 @interface NSTableView (VR)
 
 - (void)moveSelectionByDelta:(NSInteger)delta;
+- (void)moveSelectionToBottom;
+- (void)moveSelectionToTop;
 
 @end

--- a/VimR/Cocoa Categories/NSTableView+VR.m
+++ b/VimR/Cocoa Categories/NSTableView+VR.m
@@ -72,4 +72,29 @@
   }
 }
 
+- (void)scrollDownOneScreen {
+  NSRange vr = [self visibleRange];
+  NSInteger maxIndex = self.numberOfRows - 1;
+  NSUInteger mustBeVisible = MIN(vr.location + 2*vr.length - 1, maxIndex);
+
+  NSUInteger willBeSelected = mustBeVisible - vr.length + 1;
+  if (willBeSelected > self.selectedRow) {
+    [self selectRowIndexes:[NSIndexSet indexSetWithIndex:willBeSelected] byExtendingSelection:NO];
+  }
+  [self scrollRowToVisible:mustBeVisible];
+}
+
+- (void)scrollUpOneScreen {
+  NSRange vr = [self visibleRange];
+  // The difference in the second argument here might become negative. To avoid
+  // underflows of NSUInteger, we cast to NSInteger here.
+  NSInteger mustBeVisible = MAX(0, (NSInteger)vr.location - (NSInteger)vr.length);
+
+  NSUInteger willBeSelected = mustBeVisible + vr.length - 1;
+  if (willBeSelected < self.selectedRow) {
+    [self selectRowIndexes:[NSIndexSet indexSetWithIndex:willBeSelected] byExtendingSelection:NO];
+  }
+  [self scrollRowToVisible:mustBeVisible];
+}
+
 @end

--- a/VimR/Cocoa Categories/NSTableView+VR.m
+++ b/VimR/Cocoa Categories/NSTableView+VR.m
@@ -44,4 +44,32 @@
   [self scrollRowToVisible:0];
 }
 
+- (NSRange)visibleRange {
+  NSRect visibleRect = [self visibleRect];
+  return [self rowsInRect:visibleRect];
+}
+
+- (void)scrollDownOneLine {
+  NSRange vr = [self visibleRange];
+  NSInteger maxIndex = self.numberOfRows - 1;
+  NSUInteger mustBeVisible = vr.location + vr.length;
+  if (mustBeVisible <= maxIndex ) {
+    // So we will actually scroll down
+    NSUInteger willBeSelected = MAX(self.selectedRow, vr.location + 1);
+    [self selectRowIndexes:[NSIndexSet indexSetWithIndex:willBeSelected] byExtendingSelection:NO];
+    [self scrollRowToVisible:mustBeVisible];
+  }
+}
+
+- (void)scrollUpOneLine {
+  NSRange vr = [self visibleRange];
+  NSInteger mustBeVisible = vr.location - 1;
+  if (mustBeVisible >= 0) {
+    // So we will actually scroll up
+    NSUInteger willBeSelected = MIN(self.selectedRow , vr.location + vr.length - 2);
+    [self selectRowIndexes:[NSIndexSet indexSetWithIndex:willBeSelected] byExtendingSelection:NO];
+    [self scrollRowToVisible:mustBeVisible];
+  }
+}
+
 @end

--- a/VimR/Cocoa Categories/NSTableView+VR.m
+++ b/VimR/Cocoa Categories/NSTableView+VR.m
@@ -29,4 +29,19 @@
   [self scrollRowToVisible:targetIndex];
 }
 
+- (void)moveSelectionToBottom {
+  NSInteger targetIndex = self.numberOfRows - 1;
+  if (targetIndex < 0) {
+    return;
+  }
+
+  [self selectRowIndexes:[NSIndexSet indexSetWithIndex:targetIndex] byExtendingSelection:NO];
+  [self scrollRowToVisible:targetIndex];
+}
+
+- (void)moveSelectionToTop {
+  [self selectRowIndexes:[NSIndexSet indexSetWithIndex:0] byExtendingSelection:NO];
+  [self scrollRowToVisible:0];
+}
+
 @end

--- a/VimR/VRFileBrowserOutlineView.h
+++ b/VimR/VRFileBrowserOutlineView.h
@@ -38,6 +38,8 @@
 - (void)actionMoveToBottom;
 - (void)actionMoveToTop;
 - (void)actionMoveUp;
+- (void)actionScrollDownOneLine;
+- (void)actionScrollUpOneLine;
 - (void)actionFocusVimView;
 - (BOOL)actionCanActOnNode;
 - (BOOL)actionNodeIsDirectory;

--- a/VimR/VRFileBrowserOutlineView.h
+++ b/VimR/VRFileBrowserOutlineView.h
@@ -40,6 +40,8 @@
 - (void)actionMoveUp;
 - (void)actionScrollDownOneLine;
 - (void)actionScrollUpOneLine;
+- (void)actionScrollDownOneScreen;
+- (void)actionScrollUpOneScreen;
 - (void)actionFocusVimView;
 - (BOOL)actionCanActOnNode;
 - (BOOL)actionNodeIsDirectory;

--- a/VimR/VRFileBrowserOutlineView.h
+++ b/VimR/VRFileBrowserOutlineView.h
@@ -35,6 +35,8 @@
 - (void)actionSearch:(NSString *)string;
 - (void)actionReverseSearch:(NSString *)string;
 - (void)actionMoveDown;
+- (void)actionMoveToBottom;
+- (void)actionMoveToTop;
 - (void)actionMoveUp;
 - (void)actionFocusVimView;
 - (BOOL)actionCanActOnNode;

--- a/VimR/VRFileBrowserOutlineView.m
+++ b/VimR/VRFileBrowserOutlineView.m
@@ -217,23 +217,27 @@ static inline BOOL IsPrintableAscii(unichar key) {
     case 'e':
       if (modifierFlags & NSControlKeyMask) {
         [self.actionDelegate actionScrollDownOneLine];
+        return YES;
       }
-      return YES;
+      return NO;
     case 'y':
       if (modifierFlags & NSControlKeyMask) {
         [self.actionDelegate actionScrollUpOneLine];
+        return YES;
       }
-      return YES;
+      return NO;
     case 'f':
       if (modifierFlags & NSControlKeyMask) {
         [self.actionDelegate actionScrollDownOneScreen];
+        return YES;
       }
-      return YES;
+      return NO;
     case 'b':
       if (modifierFlags & NSControlKeyMask) {
         [self.actionDelegate actionScrollUpOneScreen];
+        return YES;
       }
-      return YES;
+      return NO;
     default:
       return NO;
   }

--- a/VimR/VRFileBrowserOutlineView.m
+++ b/VimR/VRFileBrowserOutlineView.m
@@ -62,6 +62,8 @@ static inline BOOL IsPrintableAscii(unichar key) {
     key = [characters characterAtIndex:0];
   }
 
+  NSEventModifierFlags modifierFlags = [event modifierFlags];
+
   if (self.actionMode != VRFileBrowserActionModeNormal && key == qEscCharacter) {
     [self.actionDelegate updateStatusMessage:@"Type <Esc> again to focus text"];
     _actionMode = VRFileBrowserActionModeNormal;
@@ -97,7 +99,7 @@ static inline BOOL IsPrintableAscii(unichar key) {
         break;
     }
   } else {
-    if ([self processKey:key]) {
+    if ([self processKey:key modifierFlags:modifierFlags]) {
       if (self.lineEditing) {
         _lineEditingString = @"";
         [self updateLineEditingStatusMessage];
@@ -124,10 +126,10 @@ static inline BOOL IsPrintableAscii(unichar key) {
 }
 
 #pragma mark Key Processing
-- (BOOL)processKey:(unichar)key {
+- (BOOL)processKey:(unichar)key modifierFlags:(NSEventModifierFlags)modifierFlags {
   switch (self.actionMode) {
     case VRFileBrowserActionModeNormal:
-      return [self processKeyModeNormal:key];
+      return [self processKeyModeNormal:key modifierFlags:modifierFlags];
     case VRFileBrowserActionModeMenu:
       return [self processKeyModeMenu:key];
     case VRFileBrowserActionModeConfirmation:
@@ -137,7 +139,7 @@ static inline BOOL IsPrintableAscii(unichar key) {
   }
 }
 
-- (BOOL)processKeyModeNormal:(unichar)key {
+- (BOOL)processKeyModeNormal:(unichar)key modifierFlags:(NSEventModifierFlags)modifierFlags {
   [self.actionDelegate updateStatusMessage:@""];
   switch (key) {
     case NSLeftArrowFunctionKey:
@@ -211,6 +213,16 @@ static inline BOOL IsPrintableAscii(unichar key) {
       return YES;
     case 'G':
       [self.actionDelegate actionMoveToBottom];
+      return YES;
+    case 'e':
+      if (modifierFlags & NSControlKeyMask) {
+        [self.actionDelegate actionScrollDownOneLine];
+      }
+      return YES;
+    case 'y':
+      if (modifierFlags & NSControlKeyMask) {
+        [self.actionDelegate actionScrollUpOneLine];
+      }
       return YES;
     default:
       return NO;

--- a/VimR/VRFileBrowserOutlineView.m
+++ b/VimR/VRFileBrowserOutlineView.m
@@ -11,6 +11,7 @@
 #import "VRUtils.h"
 
 
+static const unichar cZero = '\0'; // marks an 'undefined last key'
 static const int qEscCharacter = '\033';
 
 
@@ -39,6 +40,7 @@ static inline BOOL IsPrintableAscii(unichar key) {
 @implementation VRFileBrowserOutlineView {
   NSString *_lineEditingString;
   NSString *_lastSearch;
+  unichar _lastKey;
 }
 
 #pragma mark NSView
@@ -47,6 +49,7 @@ static inline BOOL IsPrintableAscii(unichar key) {
   RETURN_NIL_WHEN_NOT_SELF
 
   _lineEditingString = @"";
+  _lastKey = cZero;
 
   return self;
 }
@@ -103,6 +106,11 @@ static inline BOOL IsPrintableAscii(unichar key) {
       [self.actionDelegate actionIgnore];
     }
   }
+
+  // So we are done processing the keyDown event and performed our actions.
+  // We now remember the last key (useful for the 'gg' movement to the top of
+  // the view.
+  _lastKey = key;
 }
 
 - (BOOL)resignFirstResponder {
@@ -194,6 +202,15 @@ static inline BOOL IsPrintableAscii(unichar key) {
     case 'm':
       _actionMode = VRFileBrowserActionModeMenu;
       [self.actionDelegate updateStatusMessage:@"Actions: (a)dd (m)ove (d)elete (c)opy"];
+      return YES;
+    case 'g':
+      if (_lastKey == 'g') {
+        _lastKey = cZero;
+        [self.actionDelegate actionMoveToTop];
+      }
+      return YES;
+    case 'G':
+      [self.actionDelegate actionMoveToBottom];
       return YES;
     default:
       return NO;

--- a/VimR/VRFileBrowserOutlineView.m
+++ b/VimR/VRFileBrowserOutlineView.m
@@ -224,6 +224,16 @@ static inline BOOL IsPrintableAscii(unichar key) {
         [self.actionDelegate actionScrollUpOneLine];
       }
       return YES;
+    case 'f':
+      if (modifierFlags & NSControlKeyMask) {
+        [self.actionDelegate actionScrollDownOneScreen];
+      }
+      return YES;
+    case 'b':
+      if (modifierFlags & NSControlKeyMask) {
+        [self.actionDelegate actionScrollUpOneScreen];
+      }
+      return YES;
     default:
       return NO;
   }

--- a/VimR/VRFileBrowserView.m
+++ b/VimR/VRFileBrowserView.m
@@ -261,6 +261,13 @@ static NSComparisonResult (^qNodeDirComparator)(NSNumber *, NSNumber *) = ^NSCom
   [_fileOutlineView scrollUpOneLine];
 }
 
+- (void)actionScrollDownOneScreen {
+  [_fileOutlineView scrollDownOneScreen];
+}
+- (void)actionScrollUpOneScreen {
+  [_fileOutlineView scrollUpOneScreen];
+}
+
 - (void)actionFocusVimView {
   [self.window makeFirstResponder:[self.window.windowController vimView].textView];
 }

--- a/VimR/VRFileBrowserView.m
+++ b/VimR/VRFileBrowserView.m
@@ -253,6 +253,14 @@ static NSComparisonResult (^qNodeDirComparator)(NSNumber *, NSNumber *) = ^NSCom
   [_fileOutlineView moveSelectionByDelta:-1];
 }
 
+- (void)actionScrollDownOneLine {
+  [_fileOutlineView scrollDownOneLine];
+}
+
+- (void)actionScrollUpOneLine {
+  [_fileOutlineView scrollUpOneLine];
+}
+
 - (void)actionFocusVimView {
   [self.window makeFirstResponder:[self.window.windowController vimView].textView];
 }

--- a/VimR/VRFileBrowserView.m
+++ b/VimR/VRFileBrowserView.m
@@ -241,6 +241,14 @@ static NSComparisonResult (^qNodeDirComparator)(NSNumber *, NSNumber *) = ^NSCom
   [_fileOutlineView moveSelectionByDelta:1];
 }
 
+- (void)actionMoveToBottom {
+  [_fileOutlineView moveSelectionToBottom];
+}
+
+- (void)actionMoveToTop {
+  [_fileOutlineView moveSelectionToTop];
+}
+
 - (void)actionMoveUp {
   [_fileOutlineView moveSelectionByDelta:-1];
 }

--- a/VimRTests/VRFileBrowserActionTest.m
+++ b/VimRTests/VRFileBrowserActionTest.m
@@ -86,6 +86,37 @@ NSEvent *KeyDownEvent(unichar key) {
   [verify(actionDelegate) actionOpenDefault];
 }
 
+- (void)test_G_ActionShouldMoveToBottom {
+  [fileOutlineView keyDown:KeyDownEvent('G')];
+  [verify(actionDelegate) actionMoveToBottom];
+}
+
+- (void)test_gg_ActionShouldMoveToTop {
+  [fileOutlineView keyDown:KeyDownEvent('g')];
+  [fileOutlineView keyDown:KeyDownEvent('g')];
+  [verify(actionDelegate) actionMoveToTop];
+}
+
+- (void)test_ctrlE_ActionShouldScrollDownOneLine {
+  [fileOutlineView keyDown:KeyDownEventWithModifiers('e', NSControlKeyMask)];
+  [verify(actionDelegate) actionScrollDownOneLine];
+}
+
+- (void)test_ctrlY_ActionShouldScrollUpOneLine {
+  [fileOutlineView keyDown:KeyDownEventWithModifiers('y', NSControlKeyMask)];
+  [verify(actionDelegate) actionScrollUpOneLine];
+}
+
+- (void)test_ctrlF_ActionShouldScrollDownOneScreen {
+  [fileOutlineView keyDown:KeyDownEventWithModifiers('f', NSControlKeyMask)];
+  [verify(actionDelegate) actionScrollDownOneScreen];
+}
+
+- (void)test_ctrlB_ActionShouldScrollUpOneScreen {
+  [fileOutlineView keyDown:KeyDownEventWithModifiers('b', NSControlKeyMask)];
+  [verify(actionDelegate) actionScrollUpOneScreen];
+}
+
 - (void)test_down_arrow_ActionShouldMoveDown {
     [fileOutlineView keyDown:KeyDownEvent(NSDownArrowFunctionKey)];
     [verify(actionDelegate) actionMoveDown];


### PR DESCRIPTION
This pull request enables new vim-like movements to the file browser:

* It adds the vim movements `gg` and `G` that jump to the top and the bottom of the file browser
* It add the vim movements <kbd>Ctrl</kbd>+<kbd>e</kbd> and <kbd>Ctrl</kbd>+<kbd>y</kbd> that scroll up and scroll down one line
* It adds the vim movements <kbd>Ctrl</kbd>+<kbd>f</kbd> and <kbd>Ctrl</kbd>+<kbd>b</kbd> that scroll down and scroll up one page