### PR TITLE
Add lua support

### DIFF
--- a/bin/build_macvim
+++ b/bin/build_macvim
@@ -7,5 +7,12 @@ cd "$ROOT"/macvim/src
 
 [ -e auto/config.mk ] && make distclean
 
-CC=clang CPPFLAGS="-DFEAT_GUI_VIMR" ./configure --with-features=huge --enable-rubyinterp --enable-pythoninterp --enable-perlinterp --enable-cscope
+LUAJIT_BIN=$(which luajit)
+LUA_BIN_PATH=$(realpath $LUAJIT_BIN)
+if [ -n "$LUA_BIN_PATH" ]; then
+  LUA_BIN=$(dirname $LUA_BIN_PATH)
+  LUA_DIR=$(dirname $LUA_BIN)
+fi
+
+CC=clang CPPFLAGS="-DFEAT_GUI_VIMR" ./configure --with-features=huge --enable-rubyinterp --enable-pythoninterp --enable-perlinterp --enable-cscope --enable-luainterp --with-luajit --with-lua-prefix=$LUA_DIR
 make


### PR DESCRIPTION
Add `lua` support to macvim if detects `luajit` is installed, this PR is response to https://github.com/qvacua/vimr/issues/132

Steps:

1. `brew install luajit`

2. Good to go

See screenshot:

* Before, without `lua`
<img width="1437" alt="screen shot 2015-11-04 at 11 01 41 am" src="https://cloud.githubusercontent.com/assets/5491695/10948680/9f2e7d4e-82e3-11e5-8fa9-0e27e4a8f056.png">


* After, with `lua`
<img width="1432" alt="screen shot 2015-11-04 at 11 00 05 am" src="https://cloud.githubusercontent.com/assets/5491695/10948684/a51963fe-82e3-11e5-85fa-674f8e12d333.png">

