### PR TITLE
Allow to specify --cwd in the command line

### DIFF
--- a/VimR/AppDelegate.swift
+++ b/VimR/AppDelegate.swift
@@ -61,6 +61,23 @@ class AppDelegate: NSObject, NSApplicationDelegate {
       .toMergedObservables()
       .subscribe(self.actionSubject)
       .addDisposableTo(self.disposeBag)
+    
+    var actualArguments = Array(Process.arguments[1..<Process.arguments.count])
+    actualArguments = actualArguments.reverse()
+    
+    while let arg = actualArguments.popLast() {
+      switch (arg) {
+      case "--cwd":
+        let cwd = actualArguments.popLast()
+        NSFileManager.defaultManager().changeCurrentDirectoryPath(cwd!)
+        print("changing folder to \(cwd)")
+      default:
+        if (arg.characters.first == "-") {
+          // unsupported option, skip the rest
+          break
+        }
+      }
+    }
   }
 }
 


### PR DESCRIPTION
When specifying a file in command-line argument, then it opens fine. However sometimes you want to specify a working directory. neovim-dot-app does it through "--cwd" argument. 

(Related to #232)

I've added basic argument parsing and the folder will actually be switched and even the file that's specified will get properly opened:

```
open /Applications/VimR.app --args --cwd /etc/ hosts
```

![screen shot 2016-08-19 at 19 15 39](https://cloud.githubusercontent.com/assets/453929/17819753/59a09ffe-6641-11e6-8f57-391fc9ae05e2.png)

However, the `:pwd` command still shows my home folder. I wasn't been able to figure this one out.