### PR TITLE
Use %20 for spaces in filename URLs.

### DIFF
--- a/VimR/vimr
+++ b/VimR/vimr
@@ -23,7 +23,7 @@ def vimr(action, args=None, dry_run=False):
     if files:
         query_params["file"] = [os.path.abspath(f) for f in files]
 
-    url = "vimr://{0}?{1}".format(action, urllib.urlencode(query_params, True))
+    url = "vimr://{0}?{1}".format(action, urllib.urlencode(query_params, True).replace('+', '%20'))
     call_open(url, dry_run)
 
 


### PR DESCRIPTION
Files opened via the vimr cli inside a directory with spaces aren't loading correctly. This patch fixes that by using `%20` instead of `+` in the filename URL.