### PR TITLE
Support Shift-Tab

### DIFF
--- a/SwiftNeoVim/KeyUtils.swift
+++ b/SwiftNeoVim/KeyUtils.swift
@@ -56,6 +56,7 @@ class KeyUtils {
     NSF33FunctionKey: "F33",
     NSF34FunctionKey: "F34",
     NSF35FunctionKey: "F35",
+    0x19: "Tab",
   ]
 
   static func isSpecial(key: String) -> Bool {

--- a/SwiftNeoVim/NeoVimView.swift
+++ b/SwiftNeoVim/NeoVimView.swift
@@ -1036,6 +1036,7 @@ extension NeoVimView: NSTextInputClient {
     let control = modifierFlags.contains(.control)
     let option = modifierFlags.contains(.option)
     let command = modifierFlags.contains(.command)
+    let shift = modifierFlags.contains(.shift)
 
     if control {
       result += "C-"
@@ -1047,6 +1048,10 @@ extension NeoVimView: NSTextInputClient {
 
     if command {
       result += "D-"
+    }
+
+    if shift {
+      result += "S-"
     }
 
     if result.characters.count > 0 {


### PR DESCRIPTION
Closes #403, #447

---

Add (Shift-)Tab as a special key

Pressing Shift+Tab generates an NSEvent with characters `"\u{19}"` (and the
shift modifier), which the backend doesn’t recognise as the Tab key.
(Instead it gets mapped as <C-Y>, which makes sense given how ASCII control
characters are interpreted.) This change fixes that by adding a
corresponding entry to the KeyUtils.specialKeys dict.

Of course sending <C-Y> still works because it is transmitted as `<C-y>`.

---

Support shift modifier on special keys

The NeoVimView.vimModifierFlags method only checks for the control, option,
and command modifiers, which leads to the shift modifier getting lost. This
change mitigates that by checking for the shift modifier and translating it
to the `S-` key prefix.

This change has the possible side effect of requiring additional `S-`
prefixes, depending on the keyboard layout. For example, take a US keyboard
with a <kbd>-</kbd>/<kbd>_</kbd> key and press that key with control and
shift depressed. Before this change, VimR would transmit `<C-_>`, while
after this change it transmits `<C-S-_>`.