### PR TITLE
Set window as non-dirty when NeoVim stops

### DIFF
--- a/VimR/MainWindow.swift
+++ b/VimR/MainWindow.swift
@@ -409,6 +409,7 @@ extension MainWindow {
   func neoVimStopped() {
     self.isClosing = true
     self.windowController.close()
+    self.set(dirtyStatus: false)
     self.emit(self.uuidAction(for: .close))
 
     if let cliPipePath = self.cliPipePath {


### PR DESCRIPTION
Fixes #481 

I was also considering adding a new different flag, `discarded` and add that to the conditions of `AppDelegate.applicationShouldTerminate(sender:)` .
However, it seemed more straight-forward to set isDirty field to false in the delegate when NeoVim stops, as that field needs the server instance to be running in order to be useful.