### PR TITLE
Add becomeMain & resignMain methods

### DIFF
--- a/SwiftNeoVim/NeoVimView+Key.swift
+++ b/SwiftNeoVim/NeoVimView+Key.swift
@@ -229,4 +229,12 @@ extension NeoVimView {
 
     return nil
   }
+
+  public func didBecomeMain() {
+    self.agent.vimInput("<FocusGained>")
+  }
+
+  public func didResignMain() {
+    self.agent.vimInput("<FocusLost>")
+  }
 }

--- a/VimR/MainWindow.swift
+++ b/VimR/MainWindow.swift
@@ -491,6 +491,14 @@ extension MainWindow {
     self.emit(self.uuidAction(for: .becomeKey))
   }
 
+  func windowDidBecomeMain(_ notification: Notification) {
+    self.neoVimView.didBecomeMain()
+  }
+
+  func windowDidResignMain(_ notification: Notification) {
+    self.neoVimView.didResignMain()
+  }
+
   func windowShouldClose(_: Any) -> Bool {
     guard self.neoVimView.isCurrentBufferDirty() else {
       self.neoVimView.closeCurrentTab()


### PR DESCRIPTION
Hello again.

This solves issue ~#493~ #368 and allows #242 to be solved

It seems neovim expects to receive the special characters `<FocusGained>` and `<FocusLost>` (which are used by its TUI) for triggering their respective autocommand events.
I am not sure whether there's something in neovim's msgpack specifically for triggering autocommand events or not...
AFAIK originally in vim, the gui code triggered the events directly, but I'm having a hard time following the code.

There's also the detail that I don't feel quite confident on how to listen for a focus event for an osx app.

In the end, I found the `windowDidBecomeMain` and `windowDidResignMain` methods in NsWindow.
So I ended up writing small methods in `NeoVimView` and calling them from `MainWindow`

Please let me know what you think!