### PR TITLE
Catch <C-Tab> & <C-S-Tab>

### DIFF
--- a/SwiftNeoVim/KeyUtils.swift
+++ b/SwiftNeoVim/KeyUtils.swift
@@ -77,5 +77,6 @@ fileprivate let specialKeys = [
   NSF33FunctionKey: "F33",
   NSF34FunctionKey: "F34",
   NSF35FunctionKey: "F35",
+  0x09: "Tab",
   0x19: "Tab",
 ]

--- a/SwiftNeoVim/NeoVimView+Key.swift
+++ b/SwiftNeoVim/NeoVimView+Key.swift
@@ -80,6 +80,23 @@ extension NeoVimView {
     self.keyDownDone = false
   }
 
+  override public func performKeyEquivalent(with event: NSEvent) -> Bool {
+    let type = event.type
+    let flags = event.modifierFlags
+
+    /* <C-Tab> & <C-S-Tab> do not trigger keyDown events.
+       Catch the key event here and pass it to keyDown.
+       (By rogual in NeoVim dot app
+       https://github.com/rogual/neovim-dot-app/pull/248/files )
+       */
+    if .keyDown == type && flags.contains(.control) && 48 == event.keyCode {
+      self.keyDown(with: event)
+      return true
+    }
+
+    return false
+  }
+
   public func setMarkedText(_ aString: Any, selectedRange: NSRange, replacementRange: NSRange) {
     if self.markedText == nil {
       self.markedPosition = self.grid.position


### PR DESCRIPTION
Taken from https://github.com/rogual/neovim-dot-app/pull/248

There was a little extra needed in the case for `<C-Tab>`:  NsEvent.characters was returning 0x09 (Horizontal Tab) instead of 0x19 (End of Medium)

This solves #315 