### PR TITLE
Fix cjk (old approach)

### DIFF
--- a/SwiftNeoVim/MMCoreTextView.h
+++ b/SwiftNeoVim/MMCoreTextView.h
@@ -1,7 +1,7 @@
 @import Cocoa;
 @import CoreText;
 
-void recurseDraw(
+size_t recurseDraw(
     const unichar *chars,
     CGGlyph *glyphs, CGPoint *positions, UniCharCount length,
     CGContextRef context,

--- a/SwiftNeoVim/NeoVimView+Draw.swift
+++ b/SwiftNeoVim/NeoVimView+Draw.swift
@@ -67,7 +67,7 @@ extension NeoVimView {
     let glyphPositions = positions.map { CGPoint(x: $0.x, y: $0.y + offset) }
 
     self.drawer.draw(
-      string,
+      string.precomposedStringWithCanonicalMapping,
       positions: UnsafeMutablePointer(mutating: glyphPositions), positionsCount: positions.count,
       highlightAttrs: rowFrag.attrs,
       context: context


### PR DESCRIPTION
> I've made this changes before looking at MacVim's source code, which currently renders everything correctly. I'm keeping this just because.

Hi.

While looking for a root cause of #482 & #283, I noticed that sometimes position was affecting whether a glyph would show up or not.

Later I found two issues regarding surrogate characters: one which causes the position to be shifted, and another which caused `lookupFont()` to receive invalid strings.

The solution I propose is to track the amount of glyphs rendered, based on `gatherGlyphs()`.
`recurseDraw()` signature was modified for the same reason.

This only seems to solve #482 though ...

