### PR TITLE
Improve Emoji + CJK + Greek text render

### DIFF
--- a/SwiftNeoVim/NeoVimView+Draw.swift
+++ b/SwiftNeoVim/NeoVimView+Draw.swift
@@ -67,7 +67,7 @@ extension NeoVimView {
     let glyphPositions = positions.map { CGPoint(x: $0.x, y: $0.y + offset) }
 
     self.drawer.draw(
-      string.precomposedStringWithCanonicalMapping,
+      string,
       positions: UnsafeMutablePointer(mutating: glyphPositions), positionsCount: positions.count,
       highlightAttrs: rowFrag.attrs,
       context: context

--- a/SwiftNeoVim/NeoVimView+Draw.swift
+++ b/SwiftNeoVim/NeoVimView+Draw.swift
@@ -67,7 +67,7 @@ extension NeoVimView {
     let glyphPositions = positions.map { CGPoint(x: $0.x, y: $0.y + offset) }
 
     self.drawer.draw(
-      string,
+      string.precomposedStringWithCanonicalMapping,
       positions: UnsafeMutablePointer(mutating: glyphPositions), positionsCount: positions.count,
       highlightAttrs: rowFrag.attrs,
       context: context

--- a/SwiftNeoVim/NeoVimView+UiBridge.swift
+++ b/SwiftNeoVim/NeoVimView+UiBridge.swift
@@ -92,7 +92,7 @@ extension NeoVimView {
       let curPos = self.grid.position
 //      self.bridgeLogger.debug("\(curPos) -> \(string)")
 
-      self.grid.put(string)
+      self.grid.put(string.precomposedStringWithCanonicalMapping)
 
       if self.usesLigatures {
         if string == " " {

--- a/SwiftNeoVim/TextDrawer.m
+++ b/SwiftNeoVim/TextDrawer.m
@@ -197,9 +197,9 @@ static CGColorRef color_for(NSInteger value) {
     wide = CFStringIsSurrogateHighCharacter(*b) || CFStringIsSurrogateLowCharacter(*b);
     if ((b > unichars) && (wide != pWide)) {
       choppedLength = b - bStart;
-      NSString *logged = [NSString stringWithCharacters:bStart length:choppedLength];
+//      NSString *logged = [NSString stringWithCharacters:bStart length:choppedLength];
 //      NSLog(@"C(%d,%p..%p)[%@]", pWide, bStart, b, logged);
-//      recurseDraw(bStart, glyphs, p, choppedLength, context, fontWithTraits, _fontLookupCache, _usesLigatures);
+      recurseDraw(bStart, glyphs, p, choppedLength, context, fontWithTraits, _fontLookupCache, _usesLigatures);
       UniCharCount step = pWide ? choppedLength / 2 : choppedLength;
       p += step;
       g += step;


### PR DESCRIPTION
Hi. 
Lately I've been looking at #482 & #283:

#482 seems to be happening because `recurseDraw()` seems to be [expecting strings that are made of only wide-unichars or only non-wide-unichars](https://github.com/macvim-dev/macvim/blob/master/src/MacVim/gui_macvim.m#L511). This is important because [line 264](https://github.com/qvacua/vimr/blob/develop/SwiftNeoVim/MMCoreTextView.m#L264) can end up separating surrogate chars and therefore attempt to draw invalid strings.

#283 seems to be solved by normalizing the string before giving it to the `TextDrawer` in NeoVimView. 
I can't say for sure, but the fact that the bug consisted of a mysterious blank space just after a `ὑ` character makes suspect the cause is due either an inconsistency between neovim's internal representation and the string that `NeoVimView.draw()` receives: `ὑ`(`U+1F51`) vs  `υ`(`U+03C5`) + `̔`(`U+0314`)

... or maybe `recurseDraw()` needs another pre-condition that I'm missing, because macvim renders properly.

Anyways, I stumbled upon `precomposedStringWithCanonicalMapping` by reading [this](https://www.objc.io/issues/9-strings/unicode/) but tbh I don't really understand well ¯\_(ツ)_/¯