### PR TITLE
Make key handling more similar to Vim

### DIFF
--- a/SwiftNeoVim/KeyUtils.swift
+++ b/SwiftNeoVim/KeyUtils.swift
@@ -7,6 +7,18 @@ import Cocoa
 
 class KeyUtils {
 
+  static func isControlCode(key: String) -> Bool {
+    guard key.characters.count == 1 else {
+      return false
+    }
+
+    guard let firstChar = key.utf16.first else {
+      return false
+    }
+
+    return firstChar < 32 && firstChar > 0
+  }
+
   static func isSpecial(key: String) -> Bool {
     guard key.characters.count == 1 else {
       return false

--- a/SwiftNeoVim/NeoVimView+Key.swift
+++ b/SwiftNeoVim/NeoVimView+Key.swift
@@ -29,7 +29,7 @@ extension NeoVimView {
 
     let flags = self.vimModifierFlags(modifierFlags) ?? ""
     let isNamedKey = KeyUtils.isSpecial(key: charsIgnoringModifiers)
-    let isControlCode = KeyUtils.isControlCode(key: chars)
+    let isControlCode = KeyUtils.isControlCode(key: chars) && !isNamedKey
     let isPlain = flags.isEmpty && !isNamedKey
     let isWrapNeeded = !isControlCode && !isPlain
 

--- a/SwiftNeoVim/NeoVimView+Key.swift
+++ b/SwiftNeoVim/NeoVimView+Key.swift
@@ -27,22 +27,19 @@ extension NeoVimView {
       ? event.charactersIgnoringModifiers!.lowercased()
       : event.charactersIgnoringModifiers!
 
-    if KeyUtils.isSpecial(key: charsIgnoringModifiers) {
-      if let vimModifiers = self.vimModifierFlags(modifierFlags) {
-        self.agent.vimInput(
-          self.wrapNamedKeys(vimModifiers + KeyUtils.namedKeyFrom(key: charsIgnoringModifiers))
-        )
-      } else {
-        self.agent.vimInput(self.wrapNamedKeys(KeyUtils.namedKeyFrom(key: charsIgnoringModifiers)))
-      }
-    } else {
-      if let vimModifiers = self.vimModifierFlags(modifierFlags) {
-        self.agent.vimInput(self.wrapNamedKeys(vimModifiers + charsIgnoringModifiers))
-      } else {
-        self.agent.vimInput(self.vimPlainString(chars))
-      }
-    }
+    let flags = self.vimModifierFlags(modifierFlags) ?? ""
+    let isNamedKey = KeyUtils.isSpecial(key: charsIgnoringModifiers)
+    let isPlain = flags.isEmpty && !isNamedKey
+    let isWrapNeeded = !isPlain
 
+    let namedChars = isNamedKey
+        ? KeyUtils.namedKeyFrom(key: charsIgnoringModifiers)
+        : charsIgnoringModifiers
+    let finalInput = isWrapNeeded
+        ? self.wrapNamedKeys(flags + namedChars)
+        : self.vimPlainString(chars)
+
+    self.agent.vimInput(finalInput)
     self.keyDownDone = true
   }
 

--- a/SwiftNeoVim/NeoVimView+Key.swift
+++ b/SwiftNeoVim/NeoVimView+Key.swift
@@ -32,9 +32,7 @@ extension NeoVimView {
     let isPlain = flags.isEmpty && !isNamedKey
     let isWrapNeeded = !isPlain
 
-    let namedChars = isNamedKey
-        ? KeyUtils.namedKeyFrom(key: charsIgnoringModifiers)
-        : charsIgnoringModifiers
+    let namedChars = KeyUtils.namedKeyFrom(key: charsIgnoringModifiers)
     let finalInput = isWrapNeeded
         ? self.wrapNamedKeys(flags + namedChars)
         : self.vimPlainString(chars)

--- a/SwiftNeoVim/NeoVimView+Key.swift
+++ b/SwiftNeoVim/NeoVimView+Key.swift
@@ -102,6 +102,19 @@ extension NeoVimView {
       return true
     }
 
+    // For the following two conditions:
+    // See special cases in vim/os_win32.c from vim sources
+    // Also mentioned in MacVim's KeyBindings.plist
+    if .control == flags && chars == "6" {
+      self.agent.vimInput("\u{1e}")
+      return true
+    }
+    if .control == flags && chars == "2" {
+      // <C-2> should generate \0, escaping as above
+      self.agent.vimInput(self.wrapNamedKeys("Nul"))
+      return true
+    }
+
     return false
   }
 

--- a/SwiftNeoVim/NeoVimView+Key.swift
+++ b/SwiftNeoVim/NeoVimView+Key.swift
@@ -29,8 +29,9 @@ extension NeoVimView {
 
     let flags = self.vimModifierFlags(modifierFlags) ?? ""
     let isNamedKey = KeyUtils.isSpecial(key: charsIgnoringModifiers)
+    let isControlCode = KeyUtils.isControlCode(key: chars)
     let isPlain = flags.isEmpty && !isNamedKey
-    let isWrapNeeded = !isPlain
+    let isWrapNeeded = !isControlCode && !isPlain
 
     let namedChars = KeyUtils.namedKeyFrom(key: charsIgnoringModifiers)
     let finalInput = isWrapNeeded

--- a/SwiftNeoVim/NeoVimView+Key.swift
+++ b/SwiftNeoVim/NeoVimView+Key.swift
@@ -106,7 +106,7 @@ extension NeoVimView {
     // See special cases in vim/os_win32.c from vim sources
     // Also mentioned in MacVim's KeyBindings.plist
     if .control == flags && chars == "6" {
-      self.agent.vimInput("\u{1e}")
+      self.agent.vimInput("\u{1e}") // AKA ^^
       return true
     }
     if .control == flags && chars == "2" {
@@ -114,6 +114,7 @@ extension NeoVimView {
       self.agent.vimInput(self.wrapNamedKeys("Nul"))
       return true
     }
+    // NsEvent already sets \u{1f} for <C--> && <C-_>
 
     return false
   }


### PR DESCRIPTION
I decided to run some extra tests and give a deeper look at #492 

It seems that [Vim](https://github.com/vim/vim/blob/master/src/os_win32.c#L958) & [MacVim](https://github.com/macvim-dev/macvim/blob/master/src/MacVim/KeyBinding.plist#L56) have special cases for `Ctrl-2` `Ctrl-6` and `Ctrl--` after all, so I've added them.
`C--` in particular doesn't seem to be necessary in mac anyways, because `NSEvent.characters` already reports both `C--` and `C-_` as `^_`

While testing for `<C-2>` and `<C-@>` I noticed a similar problem to the one pjg had with `<C-_>`
ie. Vimr was sending `<C-S-@>` and neovim considered that different from `^@` or `<C-2>`
I haven't search as of why, but `<C-S-^>` is triggering the same behavior in neovim as `<C-^>` does. But It does the distinction when remapping either one.

Changes include:
- [C0 Control](https://en.wikipedia.org/wiki/C0_and_C1_control_codes) Characters are send as-is when detected
  - This means `<C-->` and `<C-S-_>` will send `^_` which will trigger both mappings (this solves the issue with tcomment)
- Special cases for `C-2` and `C-6` are send to neovim as `<Nul>` and `^^` respectively which is MacVim's behavior.
  - `^^` will trigger `<C-^>` mappings.  `<C-6>` mappings are lost (as all `C-` Number are unavailable in vim)
  - `<Nul>` will trigger `<C-@>` mappings. `<C-2>` sames as above

I think this is the most compatible way to handle keys, while still leaving other `<C-Number>` keys available for mapping 😄  
