### PR TITLE
Choose the “Discard and Quit” button with ⌘-D

### DIFF
--- a/VimR/AppDelegate.swift
+++ b/VimR/AppDelegate.swift
@@ -137,9 +137,11 @@ extension AppDelegate {
     if self.hasDirtyWindows && self.hasMainWindows {
       let alert = NSAlert()
       alert.addButton(withTitle: "Cancel")
-      alert.addButton(withTitle: "Discard and Quit")
+      let discardAndQuitButton = alert.addButton(withTitle: "Discard and Quit")
       alert.messageText = "There are windows with unsaved buffers!"
       alert.alertStyle = .warning
+      discardAndQuitButton.keyEquivalentModifierMask = NSCommandKeyMask
+      discardAndQuitButton.keyEquivalent = "d"
 
       if alert.runModal() == NSAlertSecondButtonReturn {
         self.uiRoot.prepareQuit()

--- a/VimR/AppDelegate.swift
+++ b/VimR/AppDelegate.swift
@@ -140,7 +140,7 @@ extension AppDelegate {
       let discardAndQuitButton = alert.addButton(withTitle: "Discard and Quit")
       alert.messageText = "There are windows with unsaved buffers!"
       alert.alertStyle = .warning
-      discardAndQuitButton.keyEquivalentModifierMask = NSCommandKeyMask
+      discardAndQuitButton.keyEquivalentModifierMask = .command
       discardAndQuitButton.keyEquivalent = "d"
 
       if alert.runModal() == NSAlertSecondButtonReturn {

--- a/VimR/MainWindow+Delegates.swift
+++ b/VimR/MainWindow+Delegates.swift
@@ -140,9 +140,11 @@ extension MainWindow {
 
     let alert = NSAlert()
     alert.addButton(withTitle: "Cancel")
-    alert.addButton(withTitle: "Discard and Close")
+    let discardAndCloseButton = alert.addButton(withTitle: "Discard and Close")
     alert.messageText = "The current buffer has unsaved changes!"
     alert.alertStyle = .warning
+    discardAndCloseButton.keyEquivalentModifierMask = .command
+    discardAndCloseButton.keyEquivalent = "d"
     alert.beginSheetModal(for: self.window, completionHandler: { response in
       if response == NSAlertSecondButtonReturn {
         self.neoVimView.closeCurrentTabWithoutSaving()


### PR DESCRIPTION
Allow quitting the application with an unsaved buffer via the keyboard. macvim makes the “Quit” button default. vimr makes the “Cancel” button default, leaving no way to “Discard and Quit” without using the mouse (as far as I can tell). 

⌘-D uses the convention of ⌘ + first letter of the button text