### PR TITLE
Custom markdown processor setting

### DIFF
--- a/VimR/VimR/GeneralPref.swift
+++ b/VimR/VimR/GeneralPref.swift
@@ -137,7 +137,7 @@ class GeneralPref: PrefPane, UiComponent, NSTextFieldDelegate {
     let customMarkdownProcessorTitle = self.titleTextField(title: "Custom Markdown Processor:")
     let customMarkdownProcessorField = self.customMarkdownProcessorField
     NotificationCenter.default.addObserver(forName: NSControl.textDidEndEditingNotification,
-                                           object: ignoreField,
+                                           object: customMarkdownProcessorField,
                                            queue: nil) { [unowned self] _ in
       self.customMarkdownProcessorAction()
     }

--- a/VimR/VimR/GeneralPrefReducer.swift
+++ b/VimR/VimR/GeneralPrefReducer.swift
@@ -28,6 +28,9 @@ class GeneralPrefReducer: ReducerType {
       state.openQuickly.ignorePatterns = patterns
       state.openQuickly.ignoreToken = Token()
 
+    case let .setCustomMarkdownProcessor(command):
+      state.mainWindowTemplate.customMarkdownProcessor = command
+      state.mainWindows.keys.forEach { state.mainWindows[$0]?.customMarkdownProcessor = command }
     }
 
     return (state, pair.action, true)

--- a/VimR/VimR/States.swift
+++ b/VimR/VimR/States.swift
@@ -271,6 +271,8 @@ extension MainWindow {
 
     var isTemporarySession = false
 
+    var customMarkdownProcessor = ""
+
     // neovim
     var uuid = UUID()
     var currentBuffer: NvimView.Buffer?
@@ -315,6 +317,7 @@ extension MainWindow {
       case useLiveResize = "use-live-resize"
       case drawsParallel = "draws-parallel"
       case isShowHidden = "is-show-hidden"
+      case customMarkdownProcessor = "custom-markdown-processor"
 
       case appearance = "appearance"
       case workspaceTools = "workspace-tool"
@@ -338,6 +341,8 @@ extension MainWindow {
       } else {
         self.frame = CGRect(x: 100, y: 100, width: 600, height: 400)
       }
+
+      self.customMarkdownProcessor = try container.decode(forKey: .customMarkdownProcessor, default: State.default.customMarkdownProcessor)
 
       self.isAllToolsVisible = try container.decode(forKey: .allToolsVisible, default: State.default.isAllToolsVisible)
       self.isToolButtonsVisible = try container.decode(forKey: .toolButtonsVisible,
@@ -388,6 +393,7 @@ extension MainWindow {
       try container.encode(self.trackpadScrollResistance, forKey: .trackpadScrollResistance)
       try container.encode(self.useLiveResize, forKey: .useLiveResize)
       try container.encode(self.drawsParallel, forKey: .drawsParallel)
+      try container.encode(self.customMarkdownProcessor, forKey: .customMarkdownProcessor)
       try container.encode(self.isLeftOptionMeta, forKey: .isLeftOptionMeta)
       try container.encode(self.isRightOptionMeta, forKey: .isRightOptionMeta)
       try container.encode(self.useInteractiveZsh, forKey: .useInteractiveZsh)


### PR DESCRIPTION
Hello! Thanks for all the work on VimR.

This allows users to set a shell command to run instead of the default markdown processor. I saw there were some issues asking for different markdown features, which is probably unavoidable since there are so many variants of markdown. Personally I use pandoc with a lot of flags to get the specific markdown variant I prefer.

This is a work in progress but I wanted to get your input. Do you think this is a good idea? I was also unsure of where to put the setting. It is currently under "General" which I'm sure is not right, but should it go under "Tools" or "Advanced"? Or maybe in the cogwheel menu at the top of the preview window?