### PR TITLE
Improve space key handling which enables <c-space> to be mapped.

### DIFF
--- a/NvimView/NvimView/KeyUtils.swift
+++ b/NvimView/NvimView/KeyUtils.swift
@@ -92,4 +92,5 @@ private let specialKeys = [
   0x09: "Tab",
   0x19: "Tab",
   0xd: "CR",
+  0x20: "Space",
 ]

--- a/NvimView/NvimView/NvimView+Key.swift
+++ b/NvimView/NvimView/NvimView+Key.swift
@@ -122,6 +122,14 @@ extension NvimView {
       return false
     }
 
+    // Space key (especially in combination with modifiers) can result in
+    // unexpected chars (e.g. ctrl-space = \0), so catch the event early and
+    // pass it to keyDown.
+    if 49 == event.keyCode {
+      self.keyDown(with: event)
+      return true
+    }
+
     guard let chars = event.characters else {
       return false;
     }


### PR DESCRIPTION
For spacebar in combination with modifiers, no `keyDown` event is triggered, but only a `performKeyEquivalent`. This PR catches the event for the spacebar keycode and calls the "normal" `keyDown` handler.
Also for the modifier-space combinations to be mapped, the `" "` character needs to be translated to `<space>` as well.
I believe that this fixes #780, as tested with:

    :nnoremap <c-space> <cmd>echo "ctrl-space pressed"<cr>