### PR TITLE
Implement configurable cursor shapes and color

### DIFF
--- a/NvimView/NvimServer/server_shared_types.h
+++ b/NvimView/NvimServer/server_shared_types.h
@@ -31,6 +31,7 @@ typedef CF_ENUM(NSInteger, NvimServerMsgId) {
   NvimServerMsgIdBusyStart,
   NvimServerMsgIdBusyStop,
   NvimServerMsgIdModeChange,
+  NvimServerMsgIdModeInfoSet,
   NvimServerMsgIdBell,
   NvimServerMsgIdVisualBell,
   NvimServerMsgIdFlush,

--- a/NvimView/NvimView.xcodeproj/project.pbxproj
+++ b/NvimView/NvimView.xcodeproj/project.pbxproj
@@ -149,6 +149,7 @@
 		4BF4FD7C2416A03B0025ACC4 /* MessagePack.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 4BB1F5CA209740E900EC394A /* MessagePack.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		4BF4FD7E2416A06D0025ACC4 /* FifoCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1929BA35C7CA9FEA9FFA3A51 /* FifoCache.swift */; };
 		4BF4FD802416A18E0025ACC4 /* GameKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4BF4FD7F2416A18E0025ACC4 /* GameKit.framework */; };
+		A1670FEA244A19E2006A05AB /* ModeInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1670FE9244A19E2006A05AB /* ModeInfo.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -360,6 +361,7 @@
 		4BF18C5A1FD2E72D00DF95D1 /* nvim */ = {isa = PBXFileReference; lastKnownFileType = folder; name = nvim; path = neovim/src/nvim; sourceTree = "<group>"; };
 		4BF18C5C1FD2EEE400DF95D1 /* NvimView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NvimView.h; sourceTree = "<group>"; };
 		4BF4FD7F2416A18E0025ACC4 /* GameKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = GameKit.framework; path = System/Library/Frameworks/GameKit.framework; sourceTree = SDKROOT; };
+		A1670FE9244A19E2006A05AB /* ModeInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModeInfo.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -450,6 +452,7 @@
 				1929B47330DAD129520A2273 /* Typesetter.swift */,
 				1929B73455764E42DACF6BB8 /* Geometry.swift */,
 				1929BB19DD03ECD6ECC35F94 /* CellAttributesCollection.swift */,
+				A1670FE9244A19E2006A05AB /* ModeInfo.swift */,
 			);
 			name = Drawing;
 			sourceTree = "<group>";
@@ -936,6 +939,7 @@
 				4B90F0351FD2AFAE008A39E0 /* NvimView+Mouse.swift in Sources */,
 				4B90F0431FD2AFAE008A39E0 /* NvimView+MenuItems.swift in Sources */,
 				4B90F0391FD2AFAE008A39E0 /* NvimView+Api.swift in Sources */,
+				A1670FEA244A19E2006A05AB /* ModeInfo.swift in Sources */,
 				4B90F0321FD2AFAE008A39E0 /* NvimView+Dragging.swift in Sources */,
 				4B90F0301FD2AFAE008A39E0 /* KeyUtils.swift in Sources */,
 				4B90F03A1FD2AFAE008A39E0 /* NvimView+Key.swift in Sources */,

--- a/NvimView/NvimView/CellAttributes.swift
+++ b/NvimView/NvimView/CellAttributes.swift
@@ -76,8 +76,8 @@ public struct CellAttributes: CustomStringConvertible, Equatable {
   public func replacingDefaults(with defaultAttributes: CellAttributes) -> CellAttributes {
     var result = self
 
-    if self.foreground == -1 { result.foreground = defaultAttributes.foreground }
-    if self.background == -1 { result.background = defaultAttributes.background }
+    if self.foreground == -1 { result.foreground = defaultAttributes.effectiveForeground }
+    if self.background == -1 { result.background = defaultAttributes.effectiveBackground }
     if self.special == -1 { result.special = defaultAttributes.special }
 
     return result

--- a/NvimView/NvimView/CellAttributesCollection.swift
+++ b/NvimView/NvimView/CellAttributesCollection.swift
@@ -21,13 +21,17 @@ final class CellAttributesCollection {
   init() { self.attributes[CellAttributesCollection.defaultAttributesId] = self.defaultAttributes }
 
   func attributes(of id: Int) -> CellAttributes? {
+    return self.attributes(of: id, withDefaults: self.defaultAttributes)
+  }
+
+  func attributes(of id: Int, withDefaults defaults: CellAttributes) -> CellAttributes? {
     if id == Int.max { return self.defaultAttributes.reversed }
 
     let absId = abs(id)
     guard let attrs = self.attributes[absId] else { return nil }
     if id < 0 { return attrs.replacingDefaults(with: self.defaultAttributes).reversed }
 
-    return attrs.replacingDefaults(with: self.defaultAttributes)
+    return attrs.replacingDefaults(with: defaults)
   }
 
   func set(attributes: CellAttributes, for id: Int) {

--- a/NvimView/NvimView/ModeInfo.swift
+++ b/NvimView/NvimView/ModeInfo.swift
@@ -5,7 +5,7 @@
 
 import MessagePack
 
-public enum CursorShape {
+public enum CursorShape : Equatable {
   case Block
   case Horizontal(cellPercentage: Int)
   case Vertical(cellPercentage: Int)
@@ -25,7 +25,6 @@ public enum CursorShape {
 }
 
 public struct ModeInfo: CustomStringConvertible {
-  public let description: String
   public let attrId: Int?
   public let cursorShape: CursorShape
   public let shortName: String
@@ -43,7 +42,9 @@ public struct ModeInfo: CustomStringConvertible {
     }
     shortName = dict["short_name"]?.stringValue ?? "?"
     name = dict["name"]?.stringValue ?? (dict["short_name"]?.stringValue ?? "???")
+  }
 
-    description = "ModeInfo<\(name) (\(shortName)) shape: \(cursorShape) attr_id:\(attrId)>"
+  public var description: String {
+    return "ModeInfo<\(name) (\(shortName)) shape: \(cursorShape) attr_id:\(attrId)>"
   }
 }

--- a/NvimView/NvimView/ModeInfo.swift
+++ b/NvimView/NvimView/ModeInfo.swift
@@ -1,0 +1,49 @@
+/**
+ * Johann Rudloff - @cypheon
+ * See LICENSE
+ */
+
+import MessagePack
+
+public enum CursorShape {
+  case Block
+  case Horizontal(cellPercentage: Int)
+  case Vertical(cellPercentage: Int)
+
+  static func of(shape: String, cellPercentage: Int?) -> CursorShape? {
+    switch shape {
+    case "block":
+      return Block
+    case "horizontal":
+      return cellPercentage.map(Horizontal(cellPercentage:))
+    case "vertical":
+      return cellPercentage.map(Vertical(cellPercentage:))
+    default:
+      return nil
+    }
+  }
+}
+
+public struct ModeInfo: CustomStringConvertible {
+  public let description: String
+  public let attrId: Int?
+  public let cursorShape: CursorShape
+  public let shortName: String
+  public let name: String
+
+  public init(
+    withMsgPackDict dict: MessagePackValue
+  ) {
+    attrId = dict["attr_id"]?.intValue
+    if let shapeName = dict["cursor_shape"]?.stringValue,
+      let cursorShape = CursorShape.of(shape: shapeName, cellPercentage: dict["cell_percentage"]?.intValue) {
+      self.cursorShape = cursorShape
+    } else {
+      self.cursorShape = .Block
+    }
+    shortName = dict["short_name"]?.stringValue ?? "?"
+    name = dict["name"]?.stringValue ?? (dict["short_name"]?.stringValue ?? "???")
+
+    description = "ModeInfo<\(name) (\(shortName)) shape: \(cursorShape) attr_id:\(attrId)>"
+  }
+}

--- a/NvimView/NvimView/NvimView+Draw.swift
+++ b/NvimView/NvimView/NvimView+Draw.swift
@@ -76,18 +76,6 @@ extension NvimView {
     let cursorPosition = self.ugrid.cursorPosition
     let defaultAttrs = self.cellAttributesCollection.defaultAttributes
 
-    if self.mode == .insert {
-      context.setFillColor(
-        ColorUtils.cgColorIgnoringAlpha(defaultAttrs.foreground)
-      )
-      var cursorRect = self.rect(
-        forRow: cursorPosition.row, column: cursorPosition.column
-      )
-      cursorRect.size.width = 2
-      context.fill(cursorRect)
-      return
-    }
-
     let cursorRegion = self.cursorRegion(for: self.ugrid.cursorPosition)
     if cursorRegion.top < 0
        || cursorRegion.bottom > self.ugrid.size.height - 1
@@ -96,14 +84,57 @@ extension NvimView {
       self.log.error("\(cursorRegion) vs. \(self.ugrid.size)")
       return
     }
-    guard let cursorAttrs = self.cellAttributesCollection.attributes(
+    guard let cellAtCursorAttrs = self.cellAttributesCollection.attributes(
       of: self.ugrid.cells[cursorPosition.row][cursorPosition.column].attrId
-    )?.reversed else {
+    ) else {
       self.log.error("Could not get the attributes" +
                      " at cursor: \(cursorPosition)")
       return
     }
 
+    guard self.modeInfoList.count > self.mode.rawValue else {
+      self.log.error("Could not get modeInfo for mode index \(self.mode.rawValue)")
+      return
+    }
+    let modeInfo = modeInfoList[Int(mode.rawValue)]
+
+    guard let cursorAttrId = modeInfo.attrId,
+      let cursorShapeAttrs = self.cellAttributesCollection.attributes(
+        of: cursorAttrId
+      ) else {
+        self.log.error("Could not get the attributes" +
+          " for cursor in mode: \(mode) \(modeInfo)")
+        return
+    }
+
+    // will be used for clipping
+    var cursorRect: CGRect
+    var cursorTextColor: Int
+
+    switch (modeInfo.cursorShape) {
+    case .Block:
+      cursorRect = self.rect(for: cursorRegion)
+      cursorTextColor = cursorShapeAttrs.effectiveForeground
+    case .Horizontal(let cellPercentage):
+      cursorRect = self.rect(for: cursorRegion)
+      cursorRect.size.height = (cursorRect.size.height * CGFloat(cellPercentage)) / 100
+      cursorTextColor = cellAtCursorAttrs.effectiveForeground
+    case .Vertical(let cellPercentage):
+      cursorRect = self.rect(forRow: cursorPosition.row, column: cursorPosition.column)
+      cursorRect.size.width = (cursorRect.size.width * CGFloat(cellPercentage)) / 100
+      cursorTextColor = cellAtCursorAttrs.effectiveForeground
+    }
+
+    let cursorAttrs = CellAttributes(
+      fontTrait: cellAtCursorAttrs.fontTrait,
+      foreground: cursorTextColor,
+      background: cursorShapeAttrs.effectiveBackground,
+      special: cellAtCursorAttrs.special,
+      reverse: false)
+
+    context.saveGState()
+    // clip to cursor rect to support shapes like "ver25" and "hor50"
+    context.clip(to: cursorRect)
     let attrsRun = AttributesRun(
       location: self.pointInView(
         forRow: cursorPosition.row, column: cursorPosition.column
@@ -117,6 +148,7 @@ extension NvimView {
       offset: self.offset,
       in: context
     )
+    context.restoreGState()
   }
 
   private func drawResizeInfo(

--- a/NvimView/NvimView/NvimView+Draw.swift
+++ b/NvimView/NvimView/NvimView+Draw.swift
@@ -100,7 +100,8 @@ extension NvimView {
 
     guard let cursorAttrId = modeInfo.attrId,
       let cursorShapeAttrs = self.cellAttributesCollection.attributes(
-        of: cursorAttrId
+        of: cursorAttrId,
+        withDefaults: cellAtCursorAttrs
       ) else {
         self.log.error("Could not get the attributes" +
           " for cursor in mode: \(mode) \(modeInfo)")

--- a/NvimView/NvimView/NvimView+UiBridge.swift
+++ b/NvimView/NvimView/NvimView+UiBridge.swift
@@ -63,7 +63,14 @@ extension NvimView {
   }
 
   final func modeInfoSet(_ value: MessagePackValue) {
+    // value[0] = cursorStyleEnabled: Bool
+    // value[1] = modeInfoList: [ModeInfo]]
     self.bridgeLogger.trace("modeInfoSet: \(value)")
+    if let mainTuple = value.arrayValue,
+        mainTuple.count == 2,
+        let modeInfoList = mainTuple[1].arrayValue?.map(ModeInfo.init(withMsgPackDict:)) {
+      self.modeInfoList = modeInfoList
+    }
   }
 
   final func flush(_ renderData: [MessagePackValue]) {

--- a/NvimView/NvimView/NvimView+UiBridge.swift
+++ b/NvimView/NvimView/NvimView+UiBridge.swift
@@ -62,6 +62,10 @@ extension NvimView {
     }
   }
 
+  final func modeInfoSet(_ value: MessagePackValue) {
+    self.bridgeLogger.trace("modeInfoSet: \(value)")
+  }
+
   final func flush(_ renderData: [MessagePackValue]) {
     self.bridgeLogger.trace("# of render data: \(renderData.count)")
 

--- a/NvimView/NvimView/NvimView.swift
+++ b/NvimView/NvimView/NvimView.swift
@@ -32,6 +32,7 @@ public class NvimView: NSView,
   public let api = RxNeovimApi()
 
   public internal(set) var mode = CursorModeShape.normal
+  public internal(set) var modeInfoList = [ModeInfo]()
 
   public internal(set) var theme = Theme.default
 

--- a/NvimView/NvimView/SharedTypes.h
+++ b/NvimView/NvimView/SharedTypes.h
@@ -31,6 +31,7 @@ typedef CF_ENUM(NSInteger, NvimServerMsgId) {
   NvimServerMsgIdBusyStart,
   NvimServerMsgIdBusyStop,
   NvimServerMsgIdModeChange,
+  NvimServerMsgIdModeInfoSet,
   NvimServerMsgIdBell,
   NvimServerMsgIdVisualBell,
   NvimServerMsgIdFlush,

--- a/NvimView/NvimView/UiBridge.swift
+++ b/NvimView/NvimView/UiBridge.swift
@@ -14,6 +14,7 @@ protocol UiBridgeConsumer: class {
   func resize(_ value: MessagePackValue)
   func clear()
   func modeChange(_ value: MessagePackValue)
+  func modeInfoSet(_ value: MessagePackValue)
   func flush(_ renderData: [MessagePackValue])
   func setTitle(with value: MessagePackValue)
   func stop()
@@ -185,6 +186,10 @@ class UiBridge {
     case .modeChange:
       guard let v = MessagePackUtils.value(from: data) else { return }
       self.consumer?.modeChange(v)
+
+    case .modeInfoSet:
+      guard let v = MessagePackUtils.value(from: data) else { return }
+      self.consumer?.modeInfoSet(v)
 
     case .bell:
       self.consumer?.bell()


### PR DESCRIPTION
Currently, the cursor always (except in insert mode) uses the current cell's colors in reverse. With the changes in this pull request, it is possible to configure VimR's cursor using the [documented standard (neo)vim methods](https://neovim.io/doc/user/options.html#'guicursor').
This allows cursor color to be specified using highlight groups and enables different cursor shapes/colors for different modes (cmdline, replace, operator pending etc).

The previous behaviour (thin vertical bar for insert mode; inverted block for all other modes) can be restored like this:

```vim
autocmd VimEnter,ColorScheme * :hi Cursor gui=reverse guibg=NONE guifg=NONE
set guicursor=a:block-Cursor
autocmd VimEnter,ColorScheme * :hi iCursor guibg=fg
set guicursor=i:ver25-iCursor
```

As I'm new to the VimR code base and it's been a while since I did some Swift coding, I'd be glad for any feedback on the code, if it's not ready to be merged :)

Some examples, what's possible now:

Backwards compatible configuration:
![cursor_backwards_compat](https://user-images.githubusercontent.com/112814/79691345-43d8b100-825f-11ea-91f4-86666988b87b.png)

New shapes and colors:
![cursor_block](https://user-images.githubusercontent.com/112814/79691346-4509de00-825f-11ea-9541-61cf49e3bdb3.png)
![cursor_hor20](https://user-images.githubusercontent.com/112814/79691349-4509de00-825f-11ea-8566-df411fe0ed35.png)
![cursor_hor50](https://user-images.githubusercontent.com/112814/79691350-45a27480-825f-11ea-84ee-ac006ef9c102.png)
![cursor_ver25](https://user-images.githubusercontent.com/112814/79691352-463b0b00-825f-11ea-9fc9-5dd33b09bbfb.png)


This probably solves the currently open cursor-configuration related issues: #590, #758

Cursor blink (#738) is currently *not* implemented. But should be easier with these changes merged.