### PR TITLE
vertically center-align text in linespacing, fixes #415

### DIFF
--- a/NvimView/NvimView/AttributesRunDrawer.swift
+++ b/NvimView/NvimView/AttributesRunDrawer.swift
@@ -24,6 +24,7 @@ final class AttributesRunDrawer {
 
   private(set) var cellSize: CGSize = .zero
   private(set) var baselineOffset: CGFloat = 0
+  private(set) var ascent: CGFloat = 0
   private(set) var descent: CGFloat = 0
   private(set) var underlinePosition: CGFloat = 0
   private(set) var underlineThickness: CGFloat = 0
@@ -181,8 +182,10 @@ final class AttributesRunDrawer {
     self.cellSize = FontUtils.cellSize(
       of: self.font, linespacing: self.linespacing, characterspacing: self.characterspacing
     )
-    self.baselineOffset = self.cellSize.height - CTFontGetAscent(self.font)
+
+    self.ascent = CTFontGetAscent(font)
     self.descent = CTFontGetDescent(font)
+    self.baselineOffset = (self.cellSize.height - ascent + descent) / 2
     self.underlinePosition = CTFontGetUnderlinePosition(font)
     self.underlineThickness = CTFontGetUnderlineThickness(font)
   }

--- a/NvimView/NvimView/AttributesRunDrawer.swift
+++ b/NvimView/NvimView/AttributesRunDrawer.swift
@@ -24,7 +24,7 @@ final class AttributesRunDrawer {
 
   private(set) var cellSize: CGSize = .zero
   private(set) var baselineOffset: CGFloat = 0
-  private(set) var ascent: CGFloat = 0
+  private(set) var textHeight: CGFloat = 0
   private(set) var descent: CGFloat = 0
   private(set) var underlinePosition: CGFloat = 0
   private(set) var underlineThickness: CGFloat = 0
@@ -183,9 +183,9 @@ final class AttributesRunDrawer {
       of: self.font, linespacing: self.linespacing, characterspacing: self.characterspacing
     )
 
-    self.ascent = CTFontGetAscent(font)
+    self.textHeight = FontUtils.cellHeight(of: font)
     self.descent = CTFontGetDescent(font)
-    self.baselineOffset = (self.cellSize.height - ascent + descent) / 2
+    self.baselineOffset = (self.cellSize.height - textHeight) / 2
     self.underlinePosition = CTFontGetUnderlinePosition(font)
     self.underlineThickness = CTFontGetUnderlineThickness(font)
   }

--- a/NvimView/NvimView/FontUtils.swift
+++ b/NvimView/NvimView/FontUtils.swift
@@ -23,6 +23,24 @@ extension FontTrait: Hashable {
 
 final class FontUtils {
 
+  static func cellHeight(of font: NSFont) -> CGFloat {
+    let ascent = CTFontGetAscent(font)
+    let descent = CTFontGetDescent(font)
+    let leading = CTFontGetLeading(font)
+
+    return ceil(ascent + descent + leading)
+  }
+
+  static func cellWidth(of font: NSFont) -> CGFloat {
+    let capitalM = [UniChar(0x004D)]
+    var glyph = [CGGlyph(0)]
+    var advancement = CGSize.zero
+    CTFontGetGlyphsForCharacters(font, capitalM, &glyph, 1)
+    CTFontGetAdvancesForGlyphs(font, .horizontal, glyph, &advancement, 1)
+
+    return advancement.width
+  }
+
   static func cellSize(of font: NSFont, linespacing: CGFloat, characterspacing: CGFloat) -> CGSize {
     if let cached = cellSizeWithDefaultLinespacingCache.valueForKey(font) {
       return CGSize(
@@ -31,21 +49,11 @@ final class FontUtils {
       )
     }
 
-    let capitalM = [UniChar(0x004D)]
-    var glyph = [CGGlyph(0)]
-    var advancement = CGSize.zero
-    CTFontGetGlyphsForCharacters(font, capitalM, &glyph, 1)
-    CTFontGetAdvancesForGlyphs(font, .horizontal, glyph, &advancement, 1)
-
-    let ascent = CTFontGetAscent(font)
-    let descent = CTFontGetDescent(font)
-    let leading = CTFontGetLeading(font)
-
-    let cellSizeToCache = CGSize(width: advancement.width, height: ceil(ascent + descent + leading))
+    let cellSizeToCache = CGSize(width: cellWidth(of: font), height: cellHeight(of: font))
     cellSizeWithDefaultLinespacingCache.set(cellSizeToCache, forKey: font)
 
     let cellSize = CGSize(
-      width: characterspacing * advancement.width,
+      width: characterspacing * cellSizeToCache.width,
       height: ceil(linespacing * cellSizeToCache.height)
     )
 


### PR DESCRIPTION
screenshots, with a ridiculous linespacing of 2.0, to exaggerate the difference:

|before|![before screenshot, displaying top-aligned text](https://user-images.githubusercontent.com/631757/79784299-f4b37e80-8339-11ea-8e9a-f83388b098da.png)|
|-|-|
|**after**|![after screenshot, displaying center-aligned text](https://user-images.githubusercontent.com/631757/79784226-d9487380-8339-11ea-8373-e8cd6d3332f9.png)|

i also have another version of this where the background is only drawn behind the actual text, not the full line. in my opinion this looks better, i'll add that commit to this PR if people prefer this version:

|narrow background|![screenshot, narrower background](https://user-images.githubusercontent.com/631757/79787943-bf119400-833f-11ea-8582-ac23dfff9415.png)|
|-|-|