### PR TITLE
Implement support for 'set guifont' via optionSet. (fixes #779)

### DIFF
--- a/NvimView/Sources/NvimView/FontUtils.swift
+++ b/NvimView/Sources/NvimView/FontUtils.swift
@@ -90,16 +90,15 @@ enum FontUtils {
         }
       }
     }
-
     return NSFont(name: fontName, size: CGFloat(fontSize))
   }
 
-  static func vimFontSpec(forFont font: NSFont) -> String? {
-    guard let escapedName = font.displayName?.components(separatedBy: " ").joined(separator: "_") else {
-      return nil
+  static func vimFontSpec(forFont font: NSFont) -> String {
+    if let escapedName = font.displayName?.components(separatedBy: " ").joined(separator: "_") {
+      return "\(escapedName):h\(Int(font.pointSize))"
     }
-
-    return "\(escapedName):h\(Int(font.pointSize))"
+    // fontName always returns a valid result and works for font(name:, size:) as well
+    return "\(font.fontName):h\(Int(font.pointSize))"
   }
 }
 

--- a/NvimView/Sources/NvimView/FontUtils.swift
+++ b/NvimView/Sources/NvimView/FontUtils.swift
@@ -70,6 +70,30 @@ enum FontUtils {
     return ctFont
   }
 
+  static func font(fromVimFontSpec fontSpec: String) -> NSFont? {
+    let fontParams = fontSpec.components(separatedBy: ":")
+
+    guard fontParams.count == 2 else {
+      return nil
+    }
+
+    let fontName = fontParams[0].components(separatedBy: "_").joined(separator: " ")
+    var fontSize = NvimView.defaultFont.pointSize // use a sane fallback
+
+    if fontParams[1].hasPrefix("h"), fontParams[1].count >= 2 {
+      let sizeSpec = fontParams[1].dropFirst()
+      if let parsed = Float(sizeSpec)?.rounded() {
+        fontSize = CGFloat(parsed)
+
+        if fontSize < NvimView.minFontSize || fontSize > NvimView.maxFontSize {
+          fontSize = NvimView.defaultFont.pointSize
+        }
+      }
+    }
+
+    return NSFont(name: fontName, size: CGFloat(fontSize))
+  }
+
   static func vimFontSpec(forFont font: NSFont) -> String? {
     guard let escapedName = font.displayName?.components(separatedBy: " ").joined(separator: "_") else {
       return nil

--- a/NvimView/Sources/NvimView/FontUtils.swift
+++ b/NvimView/Sources/NvimView/FontUtils.swift
@@ -69,6 +69,14 @@ enum FontUtils {
     fontCache.set(ctFont, forKey: sizedFontTrait)
     return ctFont
   }
+
+  static func vimFontSpec(forFont font: NSFont) -> String? {
+    guard let escapedName = font.displayName?.components(separatedBy: " ").joined(separator: "_") else {
+      return nil
+    }
+
+    return "\(escapedName):h\(Int(font.pointSize))"
+  }
 }
 
 private let fontCache = FifoCache<SizedFontTrait, NSFont>(count: 100, queueQos: .userInteractive)

--- a/NvimView/Sources/NvimView/NvimView+RemoteOptions.swift
+++ b/NvimView/Sources/NvimView/NvimView+RemoteOptions.swift
@@ -1,0 +1,75 @@
+/**
+ * Renee Koecher -  @shirk
+ * See LICENSE
+ */
+
+import Cocoa
+import MessagePack
+
+extension NvimView {
+  enum RemoteOption {
+    // list of currently handled remote options
+    case guifont(fontSpec: String)
+    case guifontWide(fontSpec: String)
+
+    static func fromValuePair(_ option: (key: MessagePackValue, value: MessagePackValue)) -> RemoteOption? {
+      switch option.key.stringValue ?? "" {
+      case "guifont": return RemoteOption.guifont(fontSpec: option.value.stringValue ?? "")
+      case "guifontwide": return RemoteOption.guifontWide(fontSpec: option.value.stringValue ?? "")
+
+      default: return nil
+      }
+    }
+  }
+
+  final func handleRemoteOptions(_ options: [MessagePackValue: MessagePackValue]) {
+    for kvPair in options {
+      guard let option = RemoteOption.fromValuePair(kvPair) else {
+        self.bridgeLogger.debug("Could not handle RemoteOption \(kvPair)")
+        continue
+      }
+
+      switch(option) {
+        // fixme: currently this treats gft and gfw the as the same
+        case .guifont(let fontSpec): handleGuifontSet(fontSpec); break
+        case .guifontWide(let fontSpec): handleGuifontSet(fontSpec); break
+      }
+    }
+  }
+
+  private final func handleGuifontSet(_ fontSpec: String) {
+    let fontParams = fontSpec.components(separatedBy: ":")
+
+    guard fontParams.count == 2 else {
+      self.bridgeLogger.debug("Invalid specification for guifont '\(fontSpec)'")
+      return
+    }
+
+    let fontName = fontParams[0].components(separatedBy: "_").joined(separator: " ")
+    var fontSize = NvimView.defaultFont.pointSize // use a sane fallback
+
+    if fontParams[1].hasPrefix("h") && fontParams[1].count >= 2 {
+      let sizeSpec = fontParams[1].dropFirst()
+      if let parsed = Float(sizeSpec)?.rounded() {
+        fontSize = CGFloat(parsed)
+
+        if fontSize < NvimView.minFontSize || fontSize > NvimView.maxFontSize {
+          fontSize = NvimView.defaultFont.pointSize
+        }
+      }
+    }
+
+    if let newFont = NSFont(name: fontName, size: CGFloat(fontSize)) {
+      gui.async {
+        self.font = newFont
+        self.markForRenderWholeView()
+        self.eventsSubject.onNext(.guifontChanged(newFont))
+      }
+    } else {
+      // todo: report an error back to NvimServer?
+      self.bridgeLogger.debug("No valid font for name=\(fontName) size=\(fontSize)")
+    }
+  }
+}
+
+private let gui = DispatchQueue.main

--- a/NvimView/Sources/NvimView/NvimView+RemoteOptions.swift
+++ b/NvimView/Sources/NvimView/NvimView+RemoteOptions.swift
@@ -29,10 +29,8 @@ extension NvimView {
     }
 
     // convenience methods
-    static func fromFont(_ font: NSFont, forWideFont isWide: Bool = false) -> RemoteOption? {
-      guard let fontSpec = FontUtils.vimFontSpec(forFont: font) else {
-        return nil
-      }
+    static func fromFont(_ font: NSFont, forWideFont isWide: Bool = false) -> RemoteOption {
+      let fontSpec = FontUtils.vimFontSpec(forFont: font)
 
       if isWide {
         return RemoteOption.guifontWide(fontSpec: fontSpec)
@@ -79,13 +77,13 @@ extension NvimView {
   private func handleGuifontSet(_ fontSpec: String, forWideFont wideFlag: Bool = false) {
     if fontSpec.isEmpty {
       // this happens on connect - signal the current value
-      self.signalRemoteOptionChange(RemoteOption.fromFont(self.font, forWideFont: wideFlag)!)
+      self.signalRemoteOptionChange(RemoteOption.fromFont(self.font, forWideFont: wideFlag))
       return
     }
 
     // stop if we would set the same font again
-    if let currentSpec = FontUtils.vimFontSpec(forFont: font),
-       currentSpec == fontSpec.components(separatedBy: " ").joined(separator: "_") {
+    let currentSpec = FontUtils.vimFontSpec(forFont: font)
+    if currentSpec == fontSpec.components(separatedBy: " ").joined(separator: "_") {
       return
     }
 
@@ -93,7 +91,7 @@ extension NvimView {
       self.bridgeLogger.debug("Invalid specification for guifont '\(fontSpec)'")
 
       self.signalError(code: 596, message: "Invalid font(s): gufont=\(fontSpec)")
-      self.signalRemoteOptionChange(RemoteOption.fromFont(self.font, forWideFont: wideFlag)!)
+      self.signalRemoteOptionChange(RemoteOption.fromFont(self.font, forWideFont: wideFlag))
       return
     }
 

--- a/NvimView/Sources/NvimView/NvimView+Types.swift
+++ b/NvimView/Sources/NvimView/NvimView+Types.swift
@@ -61,6 +61,7 @@ public extension NvimView {
     case bufferWritten(NvimView.Buffer)
 
     case colorschemeChanged(NvimView.Theme)
+    case guifontChanged(NSFont)
 
     case ipcBecameInvalid(String)
 

--- a/NvimView/Sources/NvimView/NvimView+UiBridge.swift
+++ b/NvimView/Sources/NvimView/NvimView+UiBridge.swift
@@ -14,7 +14,14 @@ extension NvimView {
     self.eventsSubject.onNext(.initVimError)
   }
 
-  final func optionSet(_: MessagePackValue) {}
+  final func optionSet(_ value: MessagePackValue) {
+    guard let options = value.dictionaryValue else {
+      self.bridgeLogger.error("Could not convert \(value)")
+      return
+    }
+
+    handleRemoteOptions(options);
+  }
 
   final func resize(_ value: MessagePackValue) {
     guard let array = MessagePackUtils.array(

--- a/NvimView/Sources/NvimView/NvimView.swift
+++ b/NvimView/Sources/NvimView/NvimView.swift
@@ -95,6 +95,10 @@ public class NvimView: NSView,
 
       self._font = newValue
       self.updateFontMetaData(newValue)
+
+      if let guifontOption = RemoteOption.fromFont(newValue) {
+        signalRemoteOptionChange(guifontOption)
+      }
     }
   }
 

--- a/NvimView/Sources/NvimView/NvimView.swift
+++ b/NvimView/Sources/NvimView/NvimView.swift
@@ -96,9 +96,7 @@ public class NvimView: NSView,
       self._font = newValue
       self.updateFontMetaData(newValue)
 
-      if let guifontOption = RemoteOption.fromFont(newValue) {
-        signalRemoteOptionChange(guifontOption)
-      }
+      signalRemoteOptionChange(RemoteOption.fromFont(newValue));
     }
   }
 

--- a/VimR/VimR/MainWindow+Delegates.swift
+++ b/VimR/VimR/MainWindow+Delegates.swift
@@ -103,6 +103,10 @@ extension MainWindow {
       .disposed(by: self.disposeBag)
   }
 
+  func guifontChanged(to font: NSFont) {
+    self.emit(self.uuidAction(for: .setFont(font)))
+  }
+
   func ipcBecameInvalid(reason: String) {
     let alert = NSAlert()
     alert.addButton(withTitle: "Close")

--- a/VimR/VimR/MainWindow.swift
+++ b/VimR/VimR/MainWindow.swift
@@ -296,6 +296,8 @@ class MainWindow: NSObject,
 
         case let .colorschemeChanged(theme): self?.colorschemeChanged(to: theme)
 
+	case let .guifontChanged(font): self?.guifontChanged(to: font)
+
         case let .ipcBecameInvalid(reason):
           self?.ipcBecameInvalid(reason: reason)
 


### PR DESCRIPTION
This adds a framework to handle options set from NvimServer and hooks into the `optionSet()` RPC api endpoint in NVimView.
Currently it handles `guifont` and `guifontwide` in the Server->View direction. 
Changes are also reflected in VimR's Preferences dialog.

Todo:
- [x] ~~sending the currently configured font as `guifont` to NvimServer~~
- [x] ~~sending an error to NvimSever if the font specification is invalid~~
- [x] ~~differentiation between `guifont` and `guifontwide`~~[1]

This PR also addresses #779 and stops vim plugins and extensions
that try to access the `guifont` setting from breaking.

There's a matching PR in NvimServer that reenables the options server-side: https://github.com/qvacua/neovim/pull/2

[1] `guifont` and `guifontwide` are handled as different options but both currently set the same font