### PR TITLE
Fix #750: incorrect cursor color when over search highlight

### DIFF
--- a/NvimView/Sources/NvimView/NvimView+Draw.swift
+++ b/NvimView/Sources/NvimView/NvimView+Draw.swift
@@ -126,7 +126,7 @@ extension NvimView {
       foreground: cursorTextColor,
       background: cursorShapeAttrs.effectiveBackground,
       special: cellAtCursorAttrs.special,
-      reverse: true
+      reverse: !cellAtCursorAttrs.reverse
     )
 
     context.saveGState()


### PR DESCRIPTION
This fixes #750: incorrect cursor color when it’s over a search highlight (when using certain color schemes).

It’s not perfect, and the contrast probably depends on the theme, but it’s much better than it was.