### PR TITLE
feat: compatible with chinese like input method

### DIFF
--- a/NvimView/Sources/NvimView/CellAttributesCollection.swift
+++ b/NvimView/Sources/NvimView/CellAttributesCollection.swift
@@ -8,6 +8,7 @@ import Foundation
 final class CellAttributesCollection {
   static let defaultAttributesId = 0
   static let reversedDefaultAttributesId = Int.max
+  static let markedAttributesId = Int.max - 1
 
   private(set) var defaultAttributes = CellAttributes(
     fontTrait: [],
@@ -24,7 +25,12 @@ final class CellAttributesCollection {
   }
 
   func attributes(of id: Int, withDefaults defaults: CellAttributes) -> CellAttributes? {
-    if id == Int.max { return self.defaultAttributes.reversed }
+    if id == Self.markedAttributesId {
+      var attr = defaultAttributes
+      attr.fontTrait.formUnion(.underline)
+      return attr
+    }
+    if id == Self.reversedDefaultAttributesId { return self.defaultAttributes.reversed }
 
     let absId = abs(id)
     guard let attrs = self.attributes[absId] else { return nil }

--- a/NvimView/Sources/NvimView/KeyUtils.swift
+++ b/NvimView/Sources/NvimView/KeyUtils.swift
@@ -37,6 +37,14 @@ class KeyUtils {
 
     return key
   }
+  static func isHalfWidth(char: Character) -> Bool {
+    // https://stackoverflow.com/questions/13505075/analyzing-full-width-or-half-width-character-in-java?noredirect=1&lq=1 // swiftlint:disable:this all
+    switch char {
+    case "\u{00}"..."\u{FF}", "\u{FF61}"..."\u{FFDC}", "\u{FFE8}"..."\u{FFEE}":
+      return true
+    default: return false
+    }
+  }
 }
 
 private let specialKeys = [

--- a/NvimView/Sources/NvimView/NvimView+Draw.swift
+++ b/NvimView/Sources/NvimView/NvimView+Draw.swift
@@ -68,10 +68,10 @@ extension NvimView {
     // the corresponding cell...
     if self.mode == .termFocus { return }
 
-    let cursorPosition = self.ugrid.cursorPosition
+    let cursorPosition = self.ugrid.cursorPositionWithMarkedInfo()
     let defaultAttrs = self.cellAttributesCollection.defaultAttributes
 
-    let cursorRegion = self.cursorRegion(for: self.ugrid.cursorPosition)
+    let cursorRegion = self.cursorRegion(for: cursorPosition)
     if cursorRegion.top < 0
       || cursorRegion.bottom > self.ugrid.size.height - 1
       || cursorRegion.left < 0

--- a/NvimView/Sources/NvimView/NvimView+Key.swift
+++ b/NvimView/Sources/NvimView/NvimView+Key.swift
@@ -59,18 +59,7 @@ public extension NvimView {
       .deleteCharacters(length, andInputEscapedString: self.vimPlainString(text))
       .wait()
 
-    if length > 0 {
-      self.ugrid.unmarkCell(at: self.markedPosition)
-      self.markForRender(position: self.markedPosition)
-      if self.ugrid.isNextCellEmpty(self.markedPosition) {
-        self.ugrid.unmarkCell(at: self.markedPosition.advancing(row: 0, column: 1))
-        self.markForRender(position: self.markedPosition.advancing(row: 0, column: 1))
-      }
-    }
-
-    self.lastMarkedText = self.markedText
-    self.markedText = nil
-    self.markedPosition = .null
+    if self.hasMarkedText() { _unmarkText() }
     self.keyDownDone = true
   }
 
@@ -195,6 +184,11 @@ public extension NvimView {
   }
 
   func unmarkText() {
+    _unmarkText()
+    self.keyDownDone = true
+  }
+
+  func _unmarkText() {
     let position = self.markedPosition
     self.ugrid.unmarkCell(at: position)
     self.markForRender(position: position)
@@ -205,7 +199,6 @@ public extension NvimView {
 
     self.markedText = nil
     self.markedPosition = .null
-    self.keyDownDone = true
   }
 
   /**

--- a/NvimView/Sources/NvimView/NvimView.swift
+++ b/NvimView/Sources/NvimView/NvimView.swift
@@ -285,8 +285,6 @@ public class NvimView: NSView,
   let disposeBag = DisposeBag()
 
   var markedText: String?
-  var markedPosition = Position.null
-
   let bridgeLogger = OSLog(subsystem: Defs.loggerSubsystem, category: Defs.LoggerCategory.bridge)
   let log = OSLog(subsystem: Defs.loggerSubsystem, category: Defs.LoggerCategory.view)
 

--- a/NvimView/Tests/NvimViewTests/TypesetterTest.swift
+++ b/NvimView/Tests/NvimViewTests/TypesetterTest.swift
@@ -432,34 +432,41 @@ class TypesetterWithLigaturesTest: XCTestCase {
     )
     expect(runs).to(haveCount(4))
 
-    // The positions of the combining characters are copied from print outputs
-    // and they are visually checked by drawing them and inspecting them...
-    var run = runs[0]
-    expect(run.font).to(equalFont(courierNew))
-    expect(run.glyphs).to(haveCount(2))
-    expect(run.positions[0])
-      .to(equal(CGPoint(x: offset.x + 1 * defaultWidth, y: offset.y)))
-    expect(run.positions[1].x)
-      .to(beCloseTo(offset.x + 1 * defaultWidth + 0.003, within: 0.001))
-    expect(run.positions[1].y).to(beCloseTo(offset.y + 0.305, within: 0.001))
+    // newest xcode(13.1) will crash at the follwing code, by use var run, and call expect(run.positions[0]). avoid crash
+    do {
+        // The positions of the combining characters are copied from print outputs
+        // and they are visually checked by drawing them and inspecting them...
+        let run = runs[0]
+        expect(run.font).to(equalFont(courierNew))
+        expect(run.glyphs).to(haveCount(2))
+        expect(run.positions[0])
+          .to(equal(CGPoint(x: offset.x + 1 * defaultWidth, y: offset.y)))
+        expect(run.positions[1].x)
+          .to(beCloseTo(offset.x + 1 * defaultWidth + 0.003, within: 0.001))
+        expect(run.positions[1].y).to(beCloseTo(offset.y + 0.305, within: 0.001))
+    }
 
-    run = runs[1]
-    expect(run.font).to(equalFont(defaultFont))
-    expect(run.glyphs).to(haveCount(2))
-    expect(run.positions[0])
-      .to(equal(CGPoint(x: offset.x + 2 * defaultWidth, y: offset.y)))
-    expect(run.positions[1].x)
-      .to(beCloseTo(offset.x + 2 * defaultWidth, within: 0.001))
-    expect(run.positions[1].y).to(beCloseTo(offset.y - 0.279, within: 0.001))
+    do {
+        let run = runs[1]
+        expect(run.font).to(equalFont(defaultFont))
+        expect(run.glyphs).to(haveCount(2))
+        expect(run.positions[0])
+          .to(equal(CGPoint(x: offset.x + 2 * defaultWidth, y: offset.y)))
+        expect(run.positions[1].x)
+          .to(beCloseTo(offset.x + 2 * defaultWidth, within: 0.001))
+        expect(run.positions[1].y).to(beCloseTo(offset.y - 0.279, within: 0.001))
+    }
 
-    run = runs[2]
-    expect(run.font).to(equalFont(monaco))
-    expect(run.glyphs).to(haveCount(2))
-    expect(run.positions[0])
-      .to(equal(CGPoint(x: offset.x + 3 * defaultWidth, y: offset.y)))
-    expect(run.positions[1].x)
-      .to(beCloseTo(offset.x + 3 * defaultWidth + 7.804, within: 0.001))
-    expect(run.positions[1].y).to(beCloseTo(offset.y + 2.446, within: 0.001))
+    do {
+        let run = runs[2]
+        expect(run.font).to(equalFont(monaco))
+        expect(run.glyphs).to(haveCount(2))
+        expect(run.positions[0])
+          .to(equal(CGPoint(x: offset.x + 3 * defaultWidth, y: offset.y)))
+        expect(run.positions[1].x)
+          .to(beCloseTo(offset.x + 3 * defaultWidth + 7.804, within: 0.001))
+        expect(run.positions[1].y).to(beCloseTo(offset.y + 2.446, within: 0.001))
+    }
 
     self.assertEmojiMarker(run: runs[3], xPosition: offset.x + 4 * defaultWidth)
   }

--- a/NvimView/Tests/NvimViewTests/UGridTest.swift
+++ b/NvimView/Tests/NvimViewTests/UGridTest.swift
@@ -161,48 +161,6 @@ class UGridTest: XCTestCase {
       .to(equal(CellAttributesCollection.reversedDefaultAttributesId))
   }
 
-  func testFlattenedIndex() {
-    self.ugrid.resize(Size(width: 20, height: 10))
-    expect(
-      self.ugrid.oneDimCellIndex(forPosition: Position(row: 0, column: 0))
-    ).to(equal(0))
-    expect(
-      self.ugrid.oneDimCellIndex(forPosition: Position(row: 0, column: 5))
-    ).to(equal(5))
-    expect(
-      self.ugrid.oneDimCellIndex(forPosition: Position(row: 1, column: 0))
-    ).to(equal(20))
-    expect(
-      self.ugrid.oneDimCellIndex(forPosition: Position(row: 1, column: 5))
-    ).to(equal(25))
-    expect(
-      self.ugrid.oneDimCellIndex(forPosition: Position(row: 9, column: 0))
-    ).to(equal(180))
-    expect(
-      self.ugrid.oneDimCellIndex(forPosition: Position(row: 9, column: 19))
-    ).to(equal(199))
-  }
-
-  func testPositionFromFlattenedIndex() {
-    self.ugrid.resize(Size(width: 20, height: 10))
-    expect(self.ugrid.position(fromOneDimCellIndex: 0))
-      .to(equal(Position(row: 0, column: 0)))
-    expect(self.ugrid.position(fromOneDimCellIndex: 5))
-      .to(equal(Position(row: 0, column: 5)))
-    expect(self.ugrid.position(fromOneDimCellIndex: 20))
-      .to(equal(Position(row: 1, column: 0)))
-    expect(self.ugrid.position(fromOneDimCellIndex: 25))
-      .to(equal(Position(row: 1, column: 5)))
-    expect(self.ugrid.position(fromOneDimCellIndex: 180))
-      .to(equal(Position(row: 9, column: 0)))
-    expect(self.ugrid.position(fromOneDimCellIndex: 199))
-      .to(equal(Position(row: 9, column: 19)))
-    expect(self.ugrid.position(fromOneDimCellIndex: 418))
-      .to(equal(Position(row: 9, column: 18)))
-    expect(self.ugrid.position(fromOneDimCellIndex: 419))
-      .to(equal(Position(row: 9, column: 19)))
-  }
-
   func testLeftBoundaryOfWord() {
     self.ugrid.resize(Size(width: 10, height: 2))
     self.ugrid.update(

--- a/docs/notes-on-cocoa-text-input.md
+++ b/docs/notes-on-cocoa-text-input.md
@@ -61,6 +61,27 @@ Let's assume we want to enter `河`: (again `hasMarkedText()` is called here and
 1. `setMarkedText("下" , selectedRange: NSRange(1, 0), replacementRange: NSRange(1, 1))` is called: the replacement range is not `NotFound` which means that we first have to delete the text in the given range, in this case the finalized `하` and then append the marked text.
 1. Selecting different Hanja calls the usual `setMarkedText(_:selectedRange:actualRange)` and `Return` finalizes the input of `河`.
 
+## Chinese Pinyin
+
+suppose we want to enter 中国
+
+1. we should enter the pinyin `zhongguo`, then `<Space>` to confirm it.
+2. each char input triggers: setMarkedText, markedRange, firstRect, attributedSubstringForProposedRange
+3. finally setMarkedText("zhong guo", selectedRange: NSRange(10, 0), replacementRange: NSRange(NotFound, 0)) iscalled:
+4. then after `<Space>` enter, insertText("中国", replacementRange: NSRange(NotFound, 0)) is called
+5. many selectedRange and attributedSubstring(forProposedRange:actualRange:) calls.
+
+this seems right simple. but when in markedtext state(before confirming it),
+1. we can use number to select other candidates
+2. we can use `=`, `-`, `<UP>`, `<DOWN>`, `<Left>`, `<Right>` to choose candidate, and vim shouldn't handle it.
+3. we can use `<Left>`, `<Right>` to move in marked text, and insert char in middle of markedText. even complicate, the move is not by char, but by word.
+
+each marked text or marked cursor changes, setMarkedText will called, with selectedRange point to the marked cursor position(may be middle, not the text end)
+
+so these key shouldn't be handle by vim directly when in marked text state.
+
+and finally we confirmed all markedtext, then a `insertText` will be called
+
 ## Other Writing System
 
 Not a clue, since I only know Latin alphabet and Korean (+Hanja)...


### PR DESCRIPTION
this PR fixes following issues when I use vim with input method:

1. use `-`, `=`, `arrow key` to select candidate. which shouldn't be
   handle by vim
2. use `left`, `right` to move in marked text by word. which shouldn't
   be handle by vim directly
3. pre-rendering marked text directly into UGrid cells, bypass vim
   key mapping system, only the finall insertText be inserted into vim.
   so vim map like jk to esc won't affect input method.
   and when input `i` in normal mode with input method, I can press <CR>
   to confirm it and only `i` will send to vim.

this PR should fixes #473 #592 #582 and may fixes #766 #771 #858 

test against docs/notes-on-cocoa-text-input.md