### PR TITLE
Esc to dismiss unsaved buffer confirmation dialog

### DIFF
--- a/VimR/VimR/AppDelegate.swift
+++ b/VimR/VimR/AppDelegate.swift
@@ -184,8 +184,9 @@ extension AppDelegate {
 
     if self.hasDirtyWindows {
       let alert = NSAlert()
-      alert.addButton(withTitle: "Cancel")
+      let cancelButton = alert.addButton(withTitle: "Cancel")
       let discardAndQuitButton = alert.addButton(withTitle: "Discard and Quit")
+      cancelButton.keyEquivalent = "\u{1b}"
       alert.messageText = "There are windows with unsaved buffers!"
       alert.alertStyle = .warning
       discardAndQuitButton.keyEquivalentModifierMask = .command

--- a/VimR/VimR/MainWindow+Delegates.swift
+++ b/VimR/VimR/MainWindow+Delegates.swift
@@ -250,8 +250,9 @@ extension MainWindow {
 
   private func discardCloseActionAlert() -> NSAlert {
     let alert = NSAlert()
-    alert.addButton(withTitle: "Cancel")
+    let cancelButton = alert.addButton(withTitle: "Cancel")
     let discardAndCloseButton = alert.addButton(withTitle: "Discard and Close")
+    cancelButton.keyEquivalent = "\u{1b}"
     alert.messageText = "The current buffer has unsaved changes!"
     alert.alertStyle = .warning
     discardAndCloseButton.keyEquivalentModifierMask = .command


### PR DESCRIPTION
When closing the VimR application with open unsaved buffers, a confirmation dialog lets the user "Discard and Quit" or "Cancel".

Also, when closing a buffer with unsaved changes, a similar confirmation dialog appears.

This PR adds a keyboard modifier to allow using the escape key to cancel. (This is the behavior in MacVim.)

I have not compiled these changes to verify the behavior. I'm on macOS 10.14.6 and can't install a newer XCode to support Swift 5.3.0 right now. (At least I think that's the issue... I've never done Swift or XCode development 🙈 ).

I found the escape key modifier string literal here: https://stackoverflow.com/questions/28541517/how-to-assign-escape-as-key-equivalent-to-a-button-in-swift/28541684

I hope this PR is useful!

![image](https://user-images.githubusercontent.com/1031/142732039-611148f9-f001-457f-b1f8-a7807b1cec43.png)

![image](https://user-images.githubusercontent.com/1031/142732026-fed03516-34c4-4439-9482-0685a008c16d.png)