### PR TITLE
README: Mention 'git submodule' commands required to build

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,9 @@ Pre-built Universal signed and notarized binaries can be found under [Releases](
 Clone this repository. Install `homebrew`, then in the project root:
 
 ```bash
+git submodule init
+git submodule update
+
 xcode-select --install # install the Xcode command line tools, if you haven't already
 brew bundle
 


### PR DESCRIPTION
Fixes #884 

## Old behavior

When `code_sign=false use_carthage_cache=false download_deps=true ./bin/build_vimr.sh` is executed:

```
### Building VimR target
### Downloading vimr-deps
#### Downloading vimr-deps-2021-12-12
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   654  100   654    0     0   5441      0 --:--:-- --:--:-- --:--:--  5686
100 1384k  100 1384k    0     0  2611k      0 --:--:-- --:--:-- --:--:-- 6785k
### Downloaded vimr-deps
### Updating carthage
*** Fetching github-markdown-css
*** Checking out github-markdown-css at "v5.0.0"
*** xcodebuild output can be found in /var/folders/6w/s6lxvwm14x56qt7gyzgj01jm0000gn/T/carthage-xcodebuild.kvKf6e.log
*** Skipped building github-markdown-css due to the error:
Dependency "github-markdown-css" has no shared framework schemes for any of the platforms: Mac

If you believe this to be an error, please file an issue with the maintainers at https://github.com/sindresorhus/github-markdown-css/issues/new
### Downloading NvimServer
cat: ./resources/nvimserver_version.txt: No such file or directory
```
Fixes #884

## New behavior

When `gitsubmodule init` and `git submodule update` are executed:

```
Submodule 'NvimServer' (git@github.com:qvacua/neovim.git) registered for path 'NvimServer'
Cloning into '/Users/t/src/vimr/NvimServer'...
Submodule path 'NvimServer': checked out '764ba0e2b54461f0bb433b76bcf2357ff9031285'
```

When `code_sign=false use_carthage_cache=false download_deps=true ./bin/build_vimr.sh` is executed:

```
### Building VimR target
### Downloading vimr-deps
#### Downloading vimr-deps-2021-12-12
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   654  100   654    0     0   5050      0 --:--:-- --:--:-- --:--:--  5360
100 1384k  100 1384k    0     0  2121k      0 --:--:-- --:--:-- --:--:-- 2121k
### Downloaded vimr-deps
### Updating carthage
*** Fetching github-markdown-css
*** Checking out github-markdown-css at "v5.0.0"
*** xcodebuild output can be found in /var/folders/6w/s6lxvwm14x56qt7gyzgj01jm0000gn/T/carthage-xcodebuild.gUiJM1.log
*** Skipped building github-markdown-css due to the error:
Dependency "github-markdown-css" has no shared framework schemes for any of the platforms: Mac

If you believe this to be an error, please file an issue with the maintainers at https://github.com/sindresorhus/github-markdown-css/issues/new
### Downloading NvimServer
#### Downloading nvimserver-0.6.1-0
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   655  100   655    0     0   2382      0 --:--:-- --:--:-- --:--:--  2399
100 7558k  100 7558k    0     0  8259k      0 --:--:-- --:--:-- --:--:-- 8259k
### Downloaded NvimServer
### Xcodebuilding
```
