### PR TITLE
[CHORE] Fix the vimr script to support python3

### DIFF
--- a/VimR/VimR/vimr
+++ b/VimR/VimR/vimr
@@ -1,12 +1,11 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
-import urllib
+import urllib.parse
 import subprocess
 import argparse
 import os
 import uuid
 import json
-
 
 class Action:
     ACTIVATE = "activate"
@@ -37,7 +36,7 @@ def call_open(action, query_params, args):
     if args.wait:
         query_params[QueryParamKey.WAIT] = "true"
 
-    url = "vimr://{0}?{1}".format(action, urllib.urlencode(query_params, True).replace('+', '%20'))
+    url = "vimr://{0}?{1}".format(action, urllib.parse.urlencode(query_params, True))
 
     if args.dry_run:
         print("/usr/bin/open {0}".format(url))
@@ -79,7 +78,7 @@ def main(args):
         os.remove(pipe_path)
 
     try:
-        os.mkfifo(pipe_path, 0600)
+        os.mkfifo(pipe_path, 0o600)
     except OSError as error:
         print("ERROR: {0}\n"
               "{1} could not be mkfifo'ed.\n"
@@ -97,7 +96,7 @@ def main(args):
         env_file = "/tmp/com_qvacua_vimr_env_{0}".format(uuid_str)
         with open(env_file, "w") as f:
             f.write(json.dumps({k: v for (k, v) in os.environ.items()}))
-            os.chmod(env_file, 0600)
+            os.chmod(env_file, 0o600)
             query_params[QueryParamKey.ENV_PATH] = env_file
 
     if args.nvim:


### PR DESCRIPTION
`python2` is pretty much on the way out... and in fact not even on a newer beta build. This converts the CLI script to support `python3` and therefore keep working.... :) Hope it helps. 