### PR TITLE
Upon switching to Enum we need to get .value

### DIFF
--- a/VimR/VimR/vimr
+++ b/VimR/VimR/vimr
@@ -37,9 +37,9 @@ def wait_for_ui_to_close(pipe_path):
 
 def call_open(action, query_params, args):
     if args.wait:
-        query_params[QueryParamKey.WAIT] = "true"
+        query_params[QueryParamKey.WAIT.value] = "true"
 
-    url = f"vimr://{action}?{urllib.parse.urlencode(query_params, True).replace('+', '%20')}"
+    url = f"vimr://{action.value}?{urllib.parse.urlencode(query_params, True).replace('+', '%20')}"
 
     if args.dry_run:
         print(f"/usr/bin/open {url}")
@@ -52,10 +52,10 @@ def abspath(path):
 
 
 def vimr_nvim(other_args, nvim_args, query_params):
-    query_params[QueryParamKey.CWD] = os.getcwd()
+    query_params[QueryParamKey.CWD.value] = os.getcwd()
 
     if nvim_args:
-        query_params[QueryParamKey.NVIM_ARGS] = nvim_args
+        query_params[QueryParamKey.NVIM_ARGS.value] = nvim_args
 
     call_open(Action.NVIM, query_params, other_args)
 
@@ -65,11 +65,11 @@ def vimr(action, args, query_params):
     if args.cwd is not None:
         cwd = abspath(args.cwd)
 
-    query_params[QueryParamKey.CWD] = cwd
+    query_params[QueryParamKey.CWD.value] = cwd
 
     files = args.file
     if files:
-        query_params[QueryParamKey.FILE] = [abspath(f) for f in files]
+        query_params[QueryParamKey.FILE.value] = [abspath(f) for f in files]
 
     call_open(action, query_params, args)
 
@@ -91,18 +91,18 @@ def main(args):
         raise
 
     query_params = {
-        QueryParamKey.PIPE_PATH: pipe_path
+        QueryParamKey.PIPE_PATH.value: pipe_path
     }
 
     if args.line is not None:
-        query_params[QueryParamKey.LINE] = args.line
+        query_params[QueryParamKey.LINE.value] = args.line
 
     if args.cur_env:
         env_file = f"/{temp_dir_path}/com_qvacua_vimr_env_{uuid_str}"
         with open(env_file, "w") as f:
             f.write(json.dumps({k: v for (k, v) in os.environ.items()}))
             os.chmod(env_file, 0o600)
-            query_params[QueryParamKey.ENV_PATH] = env_file
+            query_params[QueryParamKey.ENV_PATH.value] = env_file
 
     if args.nvim:
         nvim_parser = argparse.ArgumentParser()


### PR DESCRIPTION
We need the value not just the enum stringified so that we create a open
URL that actually functions correctly.

Without this fix, we would create the following URL (change introduced in: https://github.com/qvacua/vimr/commit/599811e8919d3cd1b00525e1fe1a47fc854f3904)

```
/usr/bin/open vimr://Action.ACTIVATE?QueryParamKey.PIPE_PATH=%2F%2Fvar%2Ffolders%2F0m%2Fddtqg4z179d4hzmyn5xjb8540000gn%2FT%2Fcom_qvacua_vimr_cli_pipe_8c27798a-2f92-47c5-94e8-bc6eb1325d01&QueryParamKey.CWD=%2FUsers%2Fc5309377%2FProjects%2Fmy-terraform
```

After this fix:

```
/usr/bin/open vimr://activate?pipe-path=%2F%2Fvar%2Ffolders%2F0m%2Fddtqg4z179d4hzmyn5xjb8540000gn%2FT%2Fcom_qvacua_vimr_cli_pipe_0e64328e-f601-4368-aa3b-a480c7e5a3f2&cwd=%2FUsers%2Fc5309377%2FProjects%2Fmy-terraform
```

Fixes #918