### PR TITLE
fix ascii input method pref and switch bug

### DIFF
--- a/NvimView/Sources/NvimView/NvimView+UiBridge.swift
+++ b/NvimView/Sources/NvimView/NvimView+UiBridge.swift
@@ -398,7 +398,8 @@ extension NvimView {
     // Enter into Insert mode, set ime to last used ime in Insert mode.
     // Visual -> Insert
     // Normal -> Insert
-    if case self.mode = CursorModeShape.insert, self.activateAsciiImInNormalMode {
+    // avoid insert -> insert
+    if case self.mode = CursorModeShape.insert, self.lastMode != self.mode, self.activateAsciiImInNormalMode {
       TISSelectInputSource(self.lastImSource)
     }
   }

--- a/VimR/VimR/MainWindow.swift
+++ b/VimR/VimR/MainWindow.swift
@@ -34,8 +34,9 @@ class MainWindow: NSObject,
   let workspace: Workspace
   let neoVimView: NvimView
 
-  var activateAsciiImInInsertMode = true {
-    didSet { self.neoVimView.activateAsciiImInNormalMode = self.activateAsciiImInInsertMode }
+  var activateAsciiImInInsertMode: Bool {
+      get { self.neoVimView.activateAsciiImInNormalMode }
+      set { self.neoVimView.activateAsciiImInNormalMode = newValue }
   }
 
   weak var shortcutService: ShortcutService?

--- a/VimR/VimR/UiRoot.swift
+++ b/VimR/VimR/UiRoot.swift
@@ -120,7 +120,9 @@ class UiRoot: UiComponent {
       emitter: self.emitter,
       state: state
     )
+    // sync global self state to child window
     mainWin.shortcutService = self.shortcutService
+    mainWin.activateAsciiImInInsertMode = self.activateAsciiImInInsertMode
 
     return mainWin
   }


### PR DESCRIPTION
see the two commit:

first commit fix pref config, currently the init state have not synced to nvimView, thus the wrong default value true is used.

second commit fix unexpected switch to ascii input method. this is because nvimview will receive insert -> insert mode change message, and when the previous record IM is ascii method, this will cause the temp open IM switch back to ascii. so just disable change im when isnert->insert

fixes #915 
