### PR TITLE
Improve trackpad scrolling precision

### DIFF
--- a/NvimView/Sources/NvimView/NvimView+Mouse.swift
+++ b/NvimView/Sources/NvimView/NvimView+Mouse.swift
@@ -68,11 +68,25 @@ extension NvimView {
       return
     }
 
-    let (absDeltaX, absDeltaY) = (
-      min(Int(ceil(abs(deltaX) / self.trackpadScrollResistance)), maxScrollDeltaX),
-      min(Int(ceil(abs(deltaY) / self.trackpadScrollResistance)), maxScrollDeltaY)
+    if event.phase == .began {
+        self.trackpadScrollDeltaX = 0
+        self.trackpadScrollDeltaY = 0
+    }
+
+    self.trackpadScrollDeltaX += deltaX
+    self.trackpadScrollDeltaY += deltaY
+    let (deltaCellX, deltaCellY) = (
+        (self.trackpadScrollDeltaX / self.cellSize.width).rounded(.toNearestOrEven),
+        (self.trackpadScrollDeltaY / self.cellSize.height).rounded(.toNearestOrEven)
     )
-    let (horizSign, vertSign) = (deltaX > 0 ? 1 : -1, deltaY > 0 ? 1 : -1)
+    self.trackpadScrollDeltaX.formRemainder(dividingBy: self.cellSize.width)
+    self.trackpadScrollDeltaY.formRemainder(dividingBy: self.cellSize.height)
+
+    let (absDeltaX, absDeltaY) = (
+      min(Int(abs(deltaCellX)), maxScrollDeltaX),
+      min(Int(abs(deltaCellY)), maxScrollDeltaY)
+    )
+    let (horizSign, vertSign) = (deltaCellX > 0 ? 1 : -1, deltaCellY > 0 ? 1 : -1)
     self.bridge
       .scroll(horizontal: horizSign * absDeltaX, vertical: vertSign * absDeltaY, at: cellPosition)
       .subscribe(onError: { [weak self] error in

--- a/NvimView/Sources/NvimView/NvimView.swift
+++ b/NvimView/Sources/NvimView/NvimView.swift
@@ -60,8 +60,6 @@ public class NvimView: NSView,
   public internal(set) var theme = Theme.default
 
   public var trackpadScrollResistance = 5.0
-  public var trackpadScrollDeltaX = 0.0
-  public var trackpadScrollDeltaY = 0.0
 
   public var usesLiveResize = false
 
@@ -286,6 +284,9 @@ public class NvimView: NSView,
 
   var scrollGuardCounterX = 5
   var scrollGuardCounterY = 5
+
+  var trackpadScrollDeltaX = 0.0
+  var trackpadScrollDeltaY = 0.0
 
   var isCurrentlyPinching = false
   var pinchTargetScale = 1.0

--- a/NvimView/Sources/NvimView/NvimView.swift
+++ b/NvimView/Sources/NvimView/NvimView.swift
@@ -60,6 +60,8 @@ public class NvimView: NSView,
   public internal(set) var theme = Theme.default
 
   public var trackpadScrollResistance = 5.0
+  public var trackpadScrollDeltaX = 0.0
+  public var trackpadScrollDeltaY = 0.0
 
   public var usesLiveResize = false
 


### PR DESCRIPTION
Hi! This is an attempt to improve handling of trackpad scrolling in `NvimView`.

The idea is to simulate 1:1 scrolling by dividing the scroll delta by `cellSize.height`,
and keep the remainder in a counter for the next iteration.
This works better than taking `ceil`, especially when the scrolling speed is slower.

I have also temporarily removed `trackpadScrollResistance` from the calculation,
as the scrolling speed no longer feels too fast to me after these changes.