### PR TITLE
Ability to reveal current buffer in file browser.

### DIFF
--- a/VimR/VimR/DefaultShortcuts.swift
+++ b/VimR/VimR/DefaultShortcuts.swift
@@ -72,5 +72,4 @@ let legacyDefaultShortcuts = [
   "com.qvacua.vimr.menuitems.window.bring-all-to-front",
   "com.qvacua.vimr.menuitems.window.minimize",
   "com.qvacua.vimr.menuitems.window.zoom",
-  "com.qvacua.vimr.file-browser.tools.reveal-current-buffer"
 ]

--- a/VimR/VimR/DefaultShortcuts.swift
+++ b/VimR/VimR/DefaultShortcuts.swift
@@ -72,4 +72,5 @@ let legacyDefaultShortcuts = [
   "com.qvacua.vimr.menuitems.window.bring-all-to-front",
   "com.qvacua.vimr.menuitems.window.minimize",
   "com.qvacua.vimr.menuitems.window.zoom",
+  "com.qvacua.vimr.file-browser.tools.reveal-current-buffer"
 ]

--- a/VimR/VimR/MainWindow+Actions.swift
+++ b/VimR/VimR/MainWindow+Actions.swift
@@ -24,6 +24,9 @@ extension MainWindow {
 
     switch event {
 
+    case .refreshFileBrowser:
+        self.refreshFileBrowser()
+
     case .revealCurrentBufferInFileBrowser:
         self.revealCurrentBufferInFileBrowser()
 

--- a/VimR/VimR/MainWindow+Actions.swift
+++ b/VimR/VimR/MainWindow+Actions.swift
@@ -23,6 +23,10 @@ extension MainWindow {
     let params = Array(rawParams.suffix(from: 1))
 
     switch event {
+
+    case .revealCurrentBufferInFileBrowser:
+        self.revealCurrentBufferInFileBrowser()
+
     case .makeSessionTemporary:
       self.emit(self.uuidAction(for: .makeSessionTemporary))
 

--- a/VimR/VimR/MainWindow.swift
+++ b/VimR/VimR/MainWindow.swift
@@ -599,6 +599,10 @@ final class MainWindow: NSObject,
   func revealCurrentBufferInFileBrowser() {
     self.fileBrowser?.scrollToSourceAction(nil)
   }
+
+  func refreshFileBrowser() {
+    self.fileBrowser?.refreshAction(nil)
+  }
 }
 
 // NvimViewDelegate

--- a/VimR/VimR/MainWindow.swift
+++ b/VimR/VimR/MainWindow.swift
@@ -595,6 +595,10 @@ final class MainWindow: NSObject,
       Swift.print("fdsfd")
     }
   }
+  
+  func revealCurrentBufferInFileBrowser() {
+    self.fileBrowser?.scrollToSourceAction(nil)
+  }
 }
 
 // NvimViewDelegate

--- a/VimR/VimR/RpcEvents.swift
+++ b/VimR/VimR/RpcEvents.swift
@@ -17,4 +17,6 @@ enum RpcEvent: String, CaseIterable {
   case setFont = "com.qvacua.vimr.rpc-events.set-font"
   case setLinespacing = "com.qvacua.vimr.rpc-events.set-linespacing"
   case setCharacterspacing = "com.qvacua.vimr.rpc-events.set-characterspacing"
+  
+  case revealCurrentBufferInFileBrowser = "com.qvacua.vimr.rpc-events.reveal-current-buffer-in-browser"
 }

--- a/VimR/VimR/RpcEvents.swift
+++ b/VimR/VimR/RpcEvents.swift
@@ -18,5 +18,6 @@ enum RpcEvent: String, CaseIterable {
   case setLinespacing = "com.qvacua.vimr.rpc-events.set-linespacing"
   case setCharacterspacing = "com.qvacua.vimr.rpc-events.set-characterspacing"
   
-  case revealCurrentBufferInFileBrowser = "com.qvacua.vimr.rpc-events.reveal-current-buffer-in-browser"
+  case revealCurrentBufferInFileBrowser = "com.qvacua.vimr.rpc-events.reveal-current-buffer-in-file-browser"
+  case refreshFileBrowser = "com.qvacua.vimr.rpc-events.refresh-file-browser"
 }

--- a/VimR/VimR/com.qvacua.VimR.vim
+++ b/VimR/VimR/com.qvacua.VimR.vim
@@ -21,14 +21,19 @@ function! s:VimRToggleToolButtons(value) abort
 	call rpcnotify(0, 'com.qvacua.NvimView', 'toggle-tool-buttons', a:value)
 endfunction
 
-function! s:VimRRevealCurrentBufferInFileExplorer() abort
-  " case revealCurrentBufferInFileBrowser = "com.qvacua.vimr.rpc-events.reveal-current-buffer-in-browser"
-	call rpcnotify(0, 'com.qvacua.NvimView', 'reveal-current-buffer-in-browser')
-endfunction
-command! -nargs=0 VimRRevealCurrentBuffer call s:VimRRevealCurrentBufferInFileExplorer()
 command! -nargs=0 VimRHideToolButtons call s:VimRToggleToolButtons(-1)
 command! -nargs=0 VimRToggleToolButtons call s:VimRToggleToolButtons(0)
 command! -nargs=0 VimRShowToolButtons call s:VimRToggleToolButtons(1)
+
+function! s:VimRRevealCurrentBufferInFileBrowser() abort
+	call rpcnotify(0, 'com.qvacua.NvimView', 'reveal-current-buffer-in-file-browser')
+endfunction
+command! -nargs=0 VimRRevealCurrentBuffer call s:VimRRevealCurrentBufferInFileBrowser()
+
+function! s:VimRRefreshFileBrowser() abort
+	call rpcnotify(0, 'com.qvacua.NvimView', 'refresh-file-browser')
+endfunction
+command! -nargs=0 VimRRefreshFileBrowser call s:VimRRefreshFileBrowser()
 
 function! s:VimRToggleFullscreen() abort
 	call rpcnotify(0, 'com.qvacua.NvimView', 'toggle-fullscreen')

--- a/VimR/VimR/com.qvacua.VimR.vim
+++ b/VimR/VimR/com.qvacua.VimR.vim
@@ -26,7 +26,9 @@ command! -nargs=0 VimRToggleToolButtons call s:VimRToggleToolButtons(0)
 command! -nargs=0 VimRShowToolButtons call s:VimRToggleToolButtons(1)
 
 function! s:VimRRevealCurrentBufferInFileBrowser() abort
-	call rpcnotify(0, 'com.qvacua.NvimView', 'reveal-current-buffer-in-file-browser')
+	if filereadable(expand('%'))
+		call rpcnotify(0, 'com.qvacua.NvimView', 'reveal-current-buffer-in-file-browser')
+	endif
 endfunction
 command! -nargs=0 VimRRevealCurrentBuffer call s:VimRRevealCurrentBufferInFileBrowser()
 

--- a/VimR/VimR/com.qvacua.VimR.vim
+++ b/VimR/VimR/com.qvacua.VimR.vim
@@ -20,6 +20,12 @@ command! -nargs=0 VimRShowTools call s:VimRToggleTools(1)
 function! s:VimRToggleToolButtons(value) abort
 	call rpcnotify(0, 'com.qvacua.NvimView', 'toggle-tool-buttons', a:value)
 endfunction
+
+function! s:VimRRevealCurrentBufferInFileExplorer() abort
+  " case revealCurrentBufferInFileBrowser = "com.qvacua.vimr.rpc-events.reveal-current-buffer-in-browser"
+	call rpcnotify(0, 'com.qvacua.NvimView', 'reveal-current-buffer-in-browser')
+endfunction
+command! -nargs=0 VimRRevealCurrentBuffer call s:VimRRevealCurrentBufferInFileExplorer()
 command! -nargs=0 VimRHideToolButtons call s:VimRToggleToolButtons(-1)
 command! -nargs=0 VimRToggleToolButtons call s:VimRToggleToolButtons(0)
 command! -nargs=0 VimRShowToolButtons call s:VimRToggleToolButtons(1)


### PR DESCRIPTION
https://github.com/qvacua/vimr/issues/953

This pr adds the new command `:VimRRevealCurrentBuffer` which reveals the current open buffer in the file browser.

Usage
`:VimRRevealCurrentBuffer`

Examples:
`autocmd BufWinEnter * VimRRevealCurrentBuffer` 
The line above makes it happen automatically: each time a buffer is opened, the associated file is displayed in the file browser.