### PR TITLE
feat: provide neovim original commandline interface

### DIFF
--- a/NvimView/Sources/NvimView/UiBridge.swift
+++ b/NvimView/Sources/NvimView/UiBridge.swift
@@ -278,7 +278,7 @@ final class UiBridge {
     // We know that NvimServer is there.
     process.launchPath = Bundle.module.url(forResource: "NvimServer", withExtension: nil)!.path
     process
-      .arguments = [self.localServerName, self.remoteServerName, usesCustomTabBarArg] +
+      .arguments = ["--gui", self.localServerName, self.remoteServerName, usesCustomTabBarArg] +
       ["--headless"] + self.nvimArgs
 
     self.log.debug(
@@ -294,6 +294,7 @@ final class UiBridge {
     let nvimCmd = [
       // We know that NvimServer is there.
       Bundle.module.url(forResource: "NvimServer", withExtension: nil)!.path,
+      "--gui",
       self.localServerName,
       self.remoteServerName,
       self.usesCustomTabBar ? "1" : "0",


### PR DESCRIPTION
see #1001, this PR expose neovim original commandline interface. so plugin can create headless subprocess in same host binary.

seealso neovim patch https://github.com/qvacua/neovim/pull/3, should merge together