### PR TITLE
Modify theming code: custom tab theme is now pulled from TablineSel highlight group

### DIFF
--- a/NvimView/Sources/NvimView/NvimView+Resize.swift
+++ b/NvimView/Sources/NvimView/NvimView+Resize.swift
@@ -126,7 +126,7 @@ extension NvimView {
             let g:gui_vimr = 1
             autocmd VimLeave * call rpcnotify(\(channel), 'autocommand', 'vimleave')
             autocmd VimEnter * call rpcnotify(\(channel), 'autocommand', 'vimenter')
-            autocmd ColorScheme * call rpcnotify(\(channel), 'autocommand', 'colorscheme', get(nvim_get_hl(0, {'id': hlID('Normal')}), 'fg', -1), get(nvim_get_hl(0, {'id': hlID('Normal')}), 'bg', -1), get(nvim_get_hl(0, {'id': hlID('Visual')}), 'fg', -1), get(nvim_get_hl(0, {'id': hlID('Visual')}), 'bg', -1), get(nvim_get_hl(0, {'id': hlID('Directory')}), 'fg', -1))
+            autocmd ColorScheme * call rpcnotify(\(channel), 'autocommand', 'colorscheme', get(nvim_get_hl(0, {'id': hlID('Normal')}), 'fg', -1), get(nvim_get_hl(0, {'id': hlID('Normal')}), 'bg', -1), get(nvim_get_hl(0, {'id': hlID('Visual')}), 'fg', -1), get(nvim_get_hl(0, {'id': hlID('Visual')}), 'bg', -1), get(nvim_get_hl(0, {'id': hlID('Directory')}), 'fg', -1), get(nvim_get_hl(0, {'id': hlID('TablineSel')}), 'bg', -1), get(nvim_get_hl(0, {'id': hlID('TablineSel')}), 'fg', -1))
             autocmd VimEnter * call rpcrequest(\(channel), 'vimenter')
             """, opts: [:], errWhenBlocked: false)
             // swiftformat:enable all

--- a/NvimView/Sources/NvimView/NvimView+Types.swift
+++ b/NvimView/Sources/NvimView/NvimView+Types.swift
@@ -101,11 +101,14 @@ public extension NvimView {
     public var visualBackground = NSColor.selectedContentBackgroundColor
 
     public var directoryForeground = NSColor.textColor
-
+	  
+    public var tabForeground = NSColor.textColor
+    public var tabBackground = NSColor.textBackgroundColor
+	  
     public init() {}
 
     public init(_ values: [Int]) {
-      if values.count < 5 { preconditionFailure("We need 5 colors!") }
+      if values.count < 7 { preconditionFailure("We need 7 colors!") }
 
       let color = ColorUtils.colorIgnoringAlpha
 
@@ -118,12 +121,15 @@ public extension NvimView {
       self.directoryForeground = values[4] < 0
         ? Theme.default.directoryForeground
         : color(values[4])
+	  self.tabBackground = values[5] < 0 ? Theme.default.background : color(values[5])
+	  self.tabForeground = values[6] < 0 ? Theme.default.foreground : color(values[6])
     }
 
     public var description: String {
       "NVV.Theme<" +
         "fg: \(self.foreground.hex), bg: \(self.background.hex), " +
         "visual-fg: \(self.visualForeground.hex), visual-bg: \(self.visualBackground.hex)" +
+        "tab-fg: \(self.tabForeground.hex), tab-bg: \(self.tabBackground.hex)" +
         ">"
     }
   }

--- a/NvimView/Sources/NvimView/NvimView+UiBridge.swift
+++ b/NvimView/Sources/NvimView/NvimView+UiBridge.swift
@@ -511,7 +511,7 @@ extension NvimView {
 
   private func colorSchemeChanged(_ value: MessagePackValue) {
     guard let values = MessagePackUtils.array(
-      from: value, ofSize: 5, conversion: { $0.intValue }
+      from: value, ofSize: 7, conversion: { $0.intValue }
     ) else {
       self.bridgeLogger.error("Could not convert \(value)")
       return

--- a/Tabs/Sources/Tabs/Tab.swift
+++ b/Tabs/Sources/Tabs/Tab.swift
@@ -107,8 +107,8 @@ extension Tab {
 
   private func adjustColors(_ newIsSelected: Bool) {
     if newIsSelected {
-      self.layer?.backgroundColor = self.theme.selectedBackgroundColor.cgColor
-      self.titleView.textColor = self.theme.selectedForegroundColor
+      self.layer?.backgroundColor = self.theme.tabBackgroundColor.cgColor
+      self.titleView.textColor = self.theme.tabForegroundColor
       self.closeButton.image = self.theme.selectedCloseButtonImage
     } else {
       self.layer?.backgroundColor = self.theme.backgroundColor.cgColor

--- a/Tabs/Sources/Tabs/Theme.swift
+++ b/Tabs/Sources/Tabs/Theme.swift
@@ -25,7 +25,7 @@ public struct Theme {
     didSet {
       self.selectedCloseButtonImage = Icon.close.asImage(
         dimension: self.iconDimension.width,
-        color: self.selectedForegroundColor
+        color: self.tabForegroundColor
       )
     }
   }
@@ -60,12 +60,12 @@ public struct Theme {
   public init() {
     self.closeButtonImage = Icon.close.asImage(
       dimension: self.iconDimension.width,
-      color: self.foregroundColor
+      color: self.tabForegroundColor
+      
     )
-
     self.selectedCloseButtonImage = Icon.close.asImage(
       dimension: self.iconDimension.width,
-      color: self.selectedForegroundColor
+      color: self.tabForegroundColor
     )
   }
 }

--- a/Tabs/Sources/Tabs/Theme.swift
+++ b/Tabs/Sources/Tabs/Theme.swift
@@ -31,8 +31,10 @@ public struct Theme {
   }
 
   public var selectedBackgroundColor = NSColor.selectedTextBackgroundColor
-
   public var tabSelectedIndicatorColor = NSColor.selectedTextColor
+
+  public var tabBackgroundColor = NSColor.selectedTextBackgroundColor
+  public var tabForegroundColor = NSColor.selectedTextColor
 
   public var titleFont = NSFont.systemFont(ofSize: 11)
   public var selectedTitleFont = NSFont.boldSystemFont(ofSize: 11)

--- a/Tabs/Support/TabsSupport/Base.lproj/MainMenu.xib
+++ b/Tabs/Support/TabsSupport/Base.lproj/MainMenu.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="17506" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="32700.99.1234" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="17506"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="22690"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -12,7 +12,7 @@
             </connections>
         </customObject>
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
-        <customObject id="-3" userLabel="Application"/>
+        <customObject id="-3" userLabel="Application" customClass="NSObject"/>
         <customObject id="Voe-Tx-rLC" customClass="AppDelegate" customModule="TabsSupport" customModuleProvider="target">
             <connections>
                 <outlet property="window" destination="QvC-M9-y7g" id="gIp-Ho-8D9"/>
@@ -685,7 +685,7 @@
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
             <rect key="contentRect" x="335" y="390" width="480" height="360"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="2880" height="1597"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="1440" height="875"/>
             <view key="contentView" id="EiT-Mj-1SZ">
                 <rect key="frame" x="0.0" y="0.0" width="480" height="360"/>
                 <autoresizingMask key="autoresizingMask"/>

--- a/Tabs/Support/TabsSupport/Base.lproj/MainMenu.xib
+++ b/Tabs/Support/TabsSupport/Base.lproj/MainMenu.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="32700.99.1234" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="17506" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="22690"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="17506"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -12,7 +12,7 @@
             </connections>
         </customObject>
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
-        <customObject id="-3" userLabel="Application" customClass="NSObject"/>
+        <customObject id="-3" userLabel="Application"/>
         <customObject id="Voe-Tx-rLC" customClass="AppDelegate" customModule="TabsSupport" customModuleProvider="target">
             <connections>
                 <outlet property="window" destination="QvC-M9-y7g" id="gIp-Ho-8D9"/>
@@ -685,7 +685,7 @@
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
             <rect key="contentRect" x="335" y="390" width="480" height="360"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="1440" height="875"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="2880" height="1597"/>
             <view key="contentView" id="EiT-Mj-1SZ">
                 <rect key="frame" x="0.0" y="0.0" width="480" height="360"/>
                 <autoresizingMask key="autoresizingMask"/>

--- a/VimR/VimR/MainWindow.swift
+++ b/VimR/VimR/MainWindow.swift
@@ -482,6 +482,9 @@ final class MainWindow: NSObject,
 
     tabsTheme.selectedForegroundColor = self.theme.highlightForeground
     tabsTheme.selectedBackgroundColor = self.theme.highlightBackground
+		
+		tabsTheme.tabBackgroundColor = self.theme.tabBackground;
+		tabsTheme.tabForegroundColor = self.theme.tabForeground;
 
     tabsTheme.tabSelectedIndicatorColor = self.theme.highlightForeground
 

--- a/VimR/VimR/Theme.swift
+++ b/VimR/VimR/Theme.swift
@@ -45,6 +45,9 @@ struct Theme: CustomStringConvertible {
   var highlightBackground = NSColor.selectedContentBackgroundColor
 
   var directoryForeground = NSColor.textColor
+	
+	  var tabForeground = NSColor.selectedMenuItemTextColor
+  var tabBackground = NSColor.selectedContentBackgroundColor
 
   var cssColor = NSColor(hex: "24292e")!
   var cssBackgroundColor = NSColor.white
@@ -62,7 +65,8 @@ struct Theme: CustomStringConvertible {
     "Theme<" +
       "fg: \(self.foreground.hex), bg: \(self.background.hex), " +
       "hl-fg: \(self.highlightForeground.hex), hl-bg: \(self.highlightBackground.hex)" +
-      "dir-fg: \(self.directoryForeground.hex)" +
+      "dir-fg: \(self.directoryForeground.hex)," +
+      "tab-bg: \(self.tabBackground.hex), tab-fg: \(self.tabForeground.hex)" +
       ">"
   }
 
@@ -76,7 +80,10 @@ struct Theme: CustomStringConvertible {
     self.highlightBackground = nvimTheme.visualBackground
 
     self.directoryForeground = nvimTheme.directoryForeground
-
+    
+		self.tabBackground = nvimTheme.tabBackground
+		self.tabForeground = nvimTheme.tabForeground
+		
     self.updateCssColors(additionalColorDict)
   }
 


### PR DESCRIPTION
Fixes the issue raised in #1058 where the `everforest` theme results in low-contrast tabs, by using color groups that were meant for tabs

**Before**
![Screenshot 2024-05-06 at 2 58 17 PM](https://github.com/qvacua/vimr/assets/2100425/c0d7fbed-c4e2-4178-9e26-e7387432d594)

**After**
![Screenshot 2024-05-06 at 2 57 50 PM](https://github.com/qvacua/vimr/assets/2100425/d22a63e1-c8d0-4316-b14b-950f7ecb2f4c)
