### PR TITLE
Make VimR tab colors match 1:1 with colorscheme.

### DIFF
--- a/NvimView/Sources/NvimView/NvimView+Types.swift
+++ b/NvimView/Sources/NvimView/NvimView+Types.swift
@@ -94,7 +94,8 @@ public extension NvimView {
     public var foreground = NSColor.textColor
     public var background = NSColor.textBackgroundColor
 
-    public var visualForeground = NSColor.selectedMenuItemTextColor
+    public var visualForeground: NSColor = NSColor(named: NSColor.Name("controlAccentColor")) ?? .selectedMenuItemTextColor
+    // NSColor.selectedMenuItemTextColor
     // NSColor.selectedMenuItemColor is deprecated. The doc says that
     // NSVisualEffectView.Material.selection should be used instead, but I don't know how to get
     // an NSColor from it.
@@ -102,13 +103,19 @@ public extension NvimView {
 
     public var directoryForeground = NSColor.textColor
 
-    public var tabForeground = NSColor.textColor
-    public var tabBackground = NSColor.textBackgroundColor
+    public var tabForeground = NSColor.controlColor
+    public var tabBackground = NSColor.controlBackgroundColor
+
+    public var tabBarForeground = NSColor.textColor
+    public var tabBarBackground = NSColor.windowBackgroundColor
+
+    public var selectedTabForeground = NSColor.selectedTextColor
+    public var selectedTabBackground = NSColor.selectedTextBackgroundColor
 
     public init() {}
 
     public init(_ values: [Int]) {
-      if values.count < 7 { preconditionFailure("We need 7 colors!") }
+      if values.count < 11 { preconditionFailure("We need 11 colors!") }
 
       let color = ColorUtils.colorIgnoringAlpha
 
@@ -121,8 +128,16 @@ public extension NvimView {
       self.directoryForeground = values[4] < 0
         ? Theme.default.directoryForeground
         : color(values[4])
-      self.tabBackground = values[5] < 0 ? Theme.default.background : color(values[5])
-      self.tabForeground = values[6] < 0 ? Theme.default.foreground : color(values[6])
+
+      self.tabBarBackground = values[5] < 0 ? Theme.default.tabBarBackground : color(values[5])
+      self.tabBarForeground = values[6] < 0 ? Theme.default.tabBarForeground : color(values[6])
+
+      self.tabBackground = values[7] < 0 ? Theme.default.tabBackground : color(values[7])
+      self.tabForeground = values[8] < 0 ? Theme.default.tabForeground : color(values[8])
+
+      self.selectedTabBackground = values[9] < 0 ? Theme.default.selectedTabBackground : color(values[9])
+      self.selectedTabForeground = values[10] < 0 ? Theme.default.selectedTabForeground : color(values[10])
+
     }
 
     public var description: String {
@@ -130,6 +145,8 @@ public extension NvimView {
         "fg: \(self.foreground.hex), bg: \(self.background.hex), " +
         "visual-fg: \(self.visualForeground.hex), visual-bg: \(self.visualBackground.hex)" +
         "tab-fg: \(self.tabForeground.hex), tab-bg: \(self.tabBackground.hex)" +
+        "tabfill-fg: \(self.tabBarForeground.hex), tabfill-bg: \(self.tabBarBackground.hex)" +
+        "tabsel-fg: \(self.selectedTabForeground.hex), tabsel-bg: \(self.selectedTabBackground.hex)" +
         ">"
     }
   }

--- a/NvimView/Sources/NvimView/NvimView+UiBridge.swift
+++ b/NvimView/Sources/NvimView/NvimView+UiBridge.swift
@@ -513,7 +513,7 @@ extension NvimView {
 
   private func colorSchemeChanged(_ value: MessagePackValue) {
     guard let values = MessagePackUtils.array(
-      from: value, ofSize: 7, conversion: { $0.intValue }
+      from: value, ofSize: 11, conversion: { $0.intValue }
     ) else {
       self.bridgeLogger.error("Could not convert \(value)")
       return

--- a/Tabs/Sources/Tabs/Tab.swift
+++ b/Tabs/Sources/Tabs/Tab.swift
@@ -107,8 +107,8 @@ extension Tab {
 
   private func adjustColors(_ newIsSelected: Bool) {
     if newIsSelected {
-      self.layer?.backgroundColor = self.theme.tabBackgroundColor.cgColor
-      self.titleView.textColor = self.theme.tabForegroundColor
+      self.layer?.backgroundColor = self.theme.selectedBackgroundColor.cgColor
+      self.titleView.textColor = self.theme.selectedForegroundColor
       self.closeButton.image = self.theme.selectedCloseButtonImage
     } else {
       self.layer?.backgroundColor = self.theme.backgroundColor.cgColor

--- a/Tabs/Sources/Tabs/TabBar.swift
+++ b/Tabs/Sources/Tabs/TabBar.swift
@@ -31,14 +31,14 @@ public final class TabBar<Rep: TabRepresentative>: NSView {
     super.init(frame: .zero)
     self.configureForAutoLayout()
     self.wantsLayer = true
-    self.layer?.backgroundColor = theme.backgroundColor.cgColor
+    self.layer?.backgroundColor =  theme.tabBarBackgroundColor.cgColor
 
     self.addViews()
   }
 
   public func update(theme: Theme) {
     self._theme = theme
-    self.layer?.backgroundColor = theme.backgroundColor.cgColor
+    self.layer?.backgroundColor = theme.tabBarBackgroundColor.cgColor
 
     self.needsDisplay = true
     self.tabs.forEach { $0.updateTheme() }

--- a/Tabs/Sources/Tabs/Theme.swift
+++ b/Tabs/Sources/Tabs/Theme.swift
@@ -9,6 +9,8 @@ import MaterialIcons
 public struct Theme {
   public static let `default` = Self()
 
+  public var separatorColor = NSColor.gridColor
+  public var backgroundColor = NSColor.textBackgroundColor
   public var foregroundColor = NSColor.textColor {
     didSet {
       self.closeButtonImage = Icon.close.asImage(
@@ -17,25 +19,21 @@ public struct Theme {
       )
     }
   }
-
-  public var backgroundColor = NSColor.textBackgroundColor
-  public var separatorColor = NSColor.gridColor
-
+	
+  public var selectedBackgroundColor = NSColor.selectedTextBackgroundColor
   public var selectedForegroundColor = NSColor.selectedTextColor {
     didSet {
       self.selectedCloseButtonImage = Icon.close.asImage(
         dimension: self.iconDimension.width,
-        color: self.tabForegroundColor
+        color: self.selectedForegroundColor
       )
     }
   }
-
-  public var selectedBackgroundColor = NSColor.selectedTextBackgroundColor
   public var tabSelectedIndicatorColor = NSColor.selectedTextColor
 
-  public var tabBackgroundColor = NSColor.selectedTextBackgroundColor
-  public var tabForegroundColor = NSColor.selectedTextColor
-
+  public var tabBarBackgroundColor = NSColor.windowBackgroundColor
+  public var tabBarForegroundColor = NSColor.textColor
+	
   public var titleFont = NSFont.systemFont(ofSize: 11)
   public var selectedTitleFont = NSFont.boldSystemFont(ofSize: 11)
 
@@ -60,12 +58,11 @@ public struct Theme {
   public init() {
     self.closeButtonImage = Icon.close.asImage(
       dimension: self.iconDimension.width,
-      color: self.tabForegroundColor
-      
+      color: self.foregroundColor
     )
     self.selectedCloseButtonImage = Icon.close.asImage(
       dimension: self.iconDimension.width,
-      color: self.tabForegroundColor
+      color: self.foregroundColor
     )
   }
 }

--- a/VimR/VimR/MainWindow.swift
+++ b/VimR/VimR/MainWindow.swift
@@ -470,16 +470,16 @@ final class MainWindow: NSObject,
   private func set(tabsThemeWith _: Theme) {
     var tabsTheme = Tabs.Theme.default
 
-    tabsTheme.foregroundColor = self.theme.foreground
-    tabsTheme.backgroundColor = self.theme.background
+    tabsTheme.foregroundColor = self.theme.tabForeground
+    tabsTheme.backgroundColor = self.theme.tabBackground
 
     tabsTheme.separatorColor = self.theme.background.brightening(by: 0.75)
 
-    tabsTheme.selectedForegroundColor = self.theme.highlightForeground
-    tabsTheme.selectedBackgroundColor = self.theme.highlightBackground
+    tabsTheme.tabBarBackgroundColor = self.theme.tabBarBackground
+    tabsTheme.tabBarForegroundColor = self.theme.tabBarForeground
 
-    tabsTheme.tabBackgroundColor = self.theme.tabBackground
-    tabsTheme.tabForegroundColor = self.theme.tabForeground
+    tabsTheme.selectedForegroundColor = self.theme.selectedTabForeground
+    tabsTheme.selectedBackgroundColor = self.theme.selectedTabBackground
 
     tabsTheme.tabSelectedIndicatorColor = self.theme.highlightForeground
 

--- a/VimR/VimR/Theme.swift
+++ b/VimR/VimR/Theme.swift
@@ -49,6 +49,12 @@ struct Theme: CustomStringConvertible {
   var tabForeground = NSColor.selectedMenuItemTextColor
   var tabBackground = NSColor.selectedContentBackgroundColor
 
+  var tabBarForeground = NSColor.selectedMenuItemTextColor
+  var tabBarBackground = NSColor.selectedContentBackgroundColor
+
+  var selectedTabForeground = NSColor.selectedMenuItemTextColor
+  var selectedTabBackground = NSColor.selectedContentBackgroundColor
+
   var cssColor = NSColor(hex: "24292e")!
   var cssBackgroundColor = NSColor.white
   var cssA = NSColor(hex: "0366d6")!
@@ -61,12 +67,14 @@ struct Theme: CustomStringConvertible {
   var cssCodeColor = NSColor(hex: "24292e")!
   var cssCodeBackgroundColor = NSColor(hex: "1b1f23")!
 
-  public var description: String {
+ public var description: String {
     "Theme<" +
       "fg: \(self.foreground.hex), bg: \(self.background.hex), " +
-      "hl-fg: \(self.highlightForeground.hex), hl-bg: \(self.highlightBackground.hex)" +
-      "dir-fg: \(self.directoryForeground.hex)," +
-      "tab-bg: \(self.tabBackground.hex), tab-fg: \(self.tabForeground.hex)" +
+      "hl-fg: \(self.highlightForeground.hex), hl-bg: \(self.highlightBackground.hex), " +
+      "dir-fg: \(self.directoryForeground.hex), " +
+      "tab-fg: \(self.tabForeground.hex), tab-bg: \(self.tabBackground.hex), " +
+      "tabfill-fg: \(self.tabBarForeground.hex), tabfill-bg: \(self.tabBarBackground.hex), " +
+      "tabsel-bg: \(self.selectedTabBackground.hex), tabsel-fg: \(self.selectedTabForeground.hex)" +
       ">"
   }
 
@@ -83,6 +91,12 @@ struct Theme: CustomStringConvertible {
 
     self.tabBackground = nvimTheme.tabBackground
     self.tabForeground = nvimTheme.tabForeground
+
+    self.tabBarBackground = nvimTheme.tabBarBackground
+    self.tabBarForeground = nvimTheme.tabBarForeground
+
+    self.selectedTabBackground = nvimTheme.selectedTabBackground
+    self.selectedTabForeground = nvimTheme.selectedTabForeground
 
     self.updateCssColors(additionalColorDict)
   }


### PR DESCRIPTION
# Background: 
See issue #1069 - Themes with Hi groups using "links" to other Hi groups do not propagate colors to SwiftUI properly.

## Description: 
This pull requests further expands upon my previous PR, more closely setting the VimR tab colors to match the colors specified by the vim colors scheme. 

Not only does it pull in the `Tabline` color definition, but it also pulls in `TablineFill` for the tabbar background, and `TablineSel` to highlight the current selected tab. 

I've also tweaked the default colors selected when VimR is not set to use vim's color scheme, and have tested in both light and dark mode.

Please look over my PR and let me know if there are any mistakes that could lead to stability problems.  So far

## Additional Change:
I noticed a TODO: regarding the default color scheme when VimR is set to use the native Coacoa colors, and added a call to NSColor.Name() to select the user's chosen accent color from system settings.

One limitation of this change is that the VimR tab UI does not pick up on changes between Dark Mode and Light Mode.  I considered polling the plist settings, but I would like to implement that with an event listener to prevent slow polling threads in the background.  I am still doing research on how to do this. 

For now, use either the Vim color scheme, or re-open the VimR window when changing the system them.

![Screenshot 2024-06-10 at 6 36 00 PM](https://github.com/qvacua/vimr/assets/2100425/1378c770-7097-4a65-89e3-32ae79f15294)

![Screenshot 2024-06-10 at 6 36 08 PM](https://github.com/qvacua/vimr/assets/2100425/fc911213-d716-4d83-8a18-aed6cc280c5a)

![Screenshot 2024-06-10 at 6 36 16 PM](https://github.com/qvacua/vimr/assets/2100425/04c6ed81-ff44-4d65-9aa4-ddfd23cf94bf)

![Screenshot 2024-06-10 at 6 36 23 PM](https://github.com/qvacua/vimr/assets/2100425/6c1f5033-003c-42ee-b2fe-6a40957ea937)
