### PR TITLE
Fix lcd/tcd

### DIFF
--- a/NvimView/Sources/NvimView/NvimView+UiBridge.swift
+++ b/NvimView/Sources/NvimView/NvimView+UiBridge.swift
@@ -508,6 +508,7 @@ extension NvimView {
 
     self.bridgeLogger.debug(cwd)
     self._cwd = URL(fileURLWithPath: cwd)
+    self.tabBar?.cwd = cwd
     self.eventsSubject.onNext(.cwdChanged)
   }
 

--- a/VimR/VimR/MainWindowReducer.swift
+++ b/VimR/VimR/MainWindowReducer.swift
@@ -19,7 +19,6 @@ final class MainWindowReducer: ReducerType {
     case let .cd(to: cwd):
       if state.cwd != cwd {
         state.cwd = cwd
-        state.cwdToSet = cwd // Ensure updates also pend to tab bar
       }
 
     case let .setBufferList(buffers):


### PR DESCRIPTION
The following code path effectively turned any `lcd` or `tcd` into a `cd`.

- `lcd` (or `tcd`) from nvim
- handled by `DirChanged` autocmd from NvimView.swift
- fires `.dirchanged` event
- handled by autoCommandEvent() in NvimView+UiBridge.swift
- calls cwdChanged() in NvimView+UiBridge.swift
- fires event `.cwdChanged`
- handled by `subscribeToNvimViewEvents()` in MainWindow.swift
- calls `cwdChanged()` in MainWindow+Delegates.swift
- fires even `.cd`
- handled by `typedReduce()` in MainWindowReducer.swift
- sets `state.cwdToSet`
- state change handled by `subscribeToStateChange()` in MainWindow.swift
- sets `self.neoVimView.cwd`
- handled by `var cwd` setter in NvimView.swift
- calls `nvimSetCurrentDir()` which sets global nvim cwd

This chain had to be broken somewhere. The `state.cwdToSet` line in MainWindowReducer.swift has a comment that it's set to "ensure updates also send to tab bar". To fix we remove that line and instead set the tab bar cwd earlier in the cahin in NvimView+UiBridge.swift.

I don't normally use the custom tab bar or file browser, but have tested them with this change and they seem to still work well.

Fixes #1027