### PR TITLE
fix: option as meta when control and command are pressed

### DIFF
--- a/NvimView/Sources/NvimView/KeyUtils.swift
+++ b/NvimView/Sources/NvimView/KeyUtils.swift
@@ -6,10 +6,11 @@
 import Cocoa
 
 enum KeyUtils {
-    static func isControlCode(key: String, flags: String = "") -> Bool {
-    if flags.contains("C-") {
-        return false
+  static func isControlCode(key: String, modifiers: NSEvent.ModifierFlags) -> Bool {
+    guard !modifiers.contains(.control) else {
+      return false
     }
+
     guard key.count == 1 else {
       return false
     }

--- a/NvimView/Sources/NvimView/KeyUtils.swift
+++ b/NvimView/Sources/NvimView/KeyUtils.swift
@@ -6,7 +6,10 @@
 import Cocoa
 
 enum KeyUtils {
-  static func isControlCode(key: String) -> Bool {
+    static func isControlCode(key: String, flags: String = "") -> Bool {
+    if flags.contains("C-") {
+        return false
+    }
     guard key.count == 1 else {
       return false
     }

--- a/NvimView/Sources/NvimView/NvimView+Key.swift
+++ b/NvimView/Sources/NvimView/NvimView+Key.swift
@@ -47,7 +47,7 @@ public extension NvimView {
 
     let flags = self.vimModifierFlags(modifierFlags) ?? ""
     let isNamedKey = KeyUtils.isSpecial(key: charsIgnoringModifiers)
-    let isControlCode = KeyUtils.isControlCode(key: chars, flags: flags) && !isNamedKey
+    let isControlCode = KeyUtils.isControlCode(key: chars, modifiers: modifierFlags) && !isNamedKey
     let isPlain = flags.isEmpty && !isNamedKey
     let isWrapNeeded = !isControlCode && !isPlain
 

--- a/NvimView/Sources/NvimView/NvimView+Key.swift
+++ b/NvimView/Sources/NvimView/NvimView+Key.swift
@@ -8,16 +8,28 @@ import MessagePack
 import RxSwift
 
 public extension NvimView {
+  private func isMeta(_ event: NSEvent) -> Bool {
+    let modifierFlags = event.modifierFlags
+
+    if (self.isLeftOptionMeta && modifierFlags.contains(.leftOption))
+        || (self.isRightOptionMeta && modifierFlags.contains(.rightOption)) {
+      return true
+    }
+
+    if modifierFlags.contains(.control) || modifierFlags.contains(.command) || event.specialKey != nil {
+      return true
+    }
+    return false
+  }
+
   override func keyDown(with event: NSEvent) {
     self.keyDownDone = false
 
     NSCursor.setHiddenUntilMouseMoves(true)
 
     let modifierFlags = event.modifierFlags
-    let isMeta = (self.isLeftOptionMeta && modifierFlags.contains(.leftOption))
-      || (self.isRightOptionMeta && modifierFlags.contains(.rightOption))
 
-    if !isMeta {
+    if !isMeta(event) {
       let cocoaHandledEvent = NSTextInputContext.current?.handleEvent(event) ?? false
       if self.hasMarkedText() {
         // mark state ignore Down,Up,Left,Right,=,- etc keys
@@ -35,7 +47,7 @@ public extension NvimView {
 
     let flags = self.vimModifierFlags(modifierFlags) ?? ""
     let isNamedKey = KeyUtils.isSpecial(key: charsIgnoringModifiers)
-    let isControlCode = KeyUtils.isControlCode(key: chars) && !isNamedKey
+    let isControlCode = KeyUtils.isControlCode(key: chars, flags: flags) && !isNamedKey
     let isPlain = flags.isEmpty && !isNamedKey
     let isWrapNeeded = !isControlCode && !isPlain
 


### PR DESCRIPTION
The proposed change is to address issue #1095 

It treats the Option key as Meta (or Alt) if either Command, or Control is also pressed. It also treats the Option key as Meta if the other pressed key is a special key (i.e. arrow keys).
In any other scenarios, the Option key behaviour is unchanged.

This allows for users of non-qwerty layouts (such as the azerty layout) to map Control+Alt sequences, while retaining the ability to insert characters that require the use of the option key (including, but not limited to `{` and `[`, in the case of the azerty layout).
This replicates the behaviour observed in common terminal emulators such as Kitty, WezTerm and Alacritty.

The "option as alt" settings are still honored and no change of behaviour is to be expected by users of these options.

I am not so happy with the `flags.contains("C-")` check in `KeyUtils.isControlCode(key:, flags:)` function, I’d be happy to have suggestions on how to improve that.