### PR TITLE
Fix Cmd+Shift+W closing only the current tab instead of the window

### DIFF
--- a/VimR/VimR/MainWindow+Delegates.swift
+++ b/VimR/VimR/MainWindow+Delegates.swift
@@ -190,6 +190,7 @@ extension MainWindow {
 
   func windowShouldClose(_: NSWindow) -> Bool {
     defer { self.closeWindow = false }
+    let closeWindow = self.closeWindow
 
     Task {
       if await self.neoVimView.isBlocked() {
@@ -200,7 +201,7 @@ extension MainWindow {
         return
       }
 
-      if self.closeWindow {
+      if closeWindow {
         if await self.neoVimView.hasDirtyBuffers() {
           self.discardCloseActionAlert().beginSheetModal(for: self.window) { response in
             if response == .alertSecondButtonReturn {


### PR DESCRIPTION
The windowShouldClose delegate method uses a defer block to reset the closeWindow flag to false. However, the logic handling the close action is performed asynchronously inside a Task. Because windowShouldClose returns immediately, the defer block executes before the Task closure runs, resetting closeWindow to false. This caused the logic inside the Task to always take the 'close tab' path instead of the 'close window' path.

This commit captures the value of self.closeWindow into a local variable before the Task, ensuring the correct value is used within the async context.

Fixed by Gemini CLI.