### PR TITLE
Optimize session loading performance by debouncing heavy UI updates

### DIFF
--- a/VimR/VimR/MainWindow+Delegates.swift
+++ b/VimR/VimR/MainWindow+Delegates.swift
@@ -56,17 +56,15 @@ extension MainWindow {
   }
 
   func cwdChanged() {
-    self.emit(self.uuidAction(for: .cd(to: self.neoVimView.cwd)))
+    self.uiSyncSubject.send()
   }
 
   func bufferListChanged() async {
-    let bufs = await self.neoVimView.allBuffers() ?? []
-    let action = self.uuidAction(for: .setBufferList(bufs.filter(\.isListed)))
-    self.emit(action)
+    self.uiSyncSubject.send()
   }
 
-  func bufferWritten(_ buffer: NvimView.Buffer) {
-    self.emit(self.uuidAction(for: .bufferWritten(buffer)))
+  func bufferWritten(_: NvimView.Buffer) {
+    self.uiSyncSubject.send()
   }
 
   func newCurrentBuffer(_ currentBuffer: NvimView.Buffer) {


### PR DESCRIPTION
Startify session loading triggers a storm of RPC events (bufferListChanged, refreshFileBrowser, etc.) from Neovim. Previously, VimR responded to each event individually, causing excessive RPC calls (e.g., fetching all buffers) and UI updates (File Browser refresh), resulting in severe lag.

This commit implements a debouncing strategy to coalesce these frequent, heavy updates:
1. Introduces `uiSyncSubject` in `MainWindow` to debounce heavy update requests with a 200ms interval.
2. Redirects `bufferListChanged`, `cwdChanged`, `bufferWritten`, `refreshFileBrowser`, and `revealCurrentBufferInFileBrowser` to this debouncer.
3. Implements `syncUiWithNvim` to perform a single, batched update of the buffer list, CWD, and File Browser state after the debounce interval.
4. Keeps `newCurrentBuffer` and `tabChanged` as direct, non-debounced updates to ensure immediate UI responsiveness (e.g., window title, tab bar) during manual interactions.

This significantly improves session loading speed while maintaining a responsive UI for daily usage.

Implemented by Gemini CLI.