### PR TITLE
Enhance local build system for faster iteration and better DX

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,10 +63,19 @@ git submodule update --init
 
 xcode-select --install # install the Xcode command line tools, if you haven't already
 brew bundle # install dependencies, e.g., build tools for Neovim
-clean=true notarize=false ./bin/build_vimr.sh
+clean=true notarize=false trust_plugins=true ./bin/build_vimr.sh
 ```
 
+*   `trust_plugins=true`: Skips the interactive package plugin validation (SwiftLint), allowing the build to proceed in a non-interactive shell.
+*   `notarize=false`: Skips the Apple notarization process and performs an ad-hoc signature instead.
+
 The built application will be located at `./build/Build/Products/Release/VimR.app`.
+
+For convenience, you can use the helper script to build and overwrite the application in `/Applications`:
+
+```bash
+./bin/build_and_install_local_release.sh
+```
 
 ## Development
 

--- a/bin/build_and_install_local_release.sh
+++ b/bin/build_and_install_local_release.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+set -Eeuo pipefail
+
+# Use environment variable 'clean' if set, otherwise default to false
+clean=${clean:-false}
+
+main() {
+  local -r script_path=$(
+    cd "$(dirname "${BASH_SOURCE[0]}")"
+    pwd -P
+  )
+  local -r project_root="${script_path}/.."
+  local -r build_products_path="${project_root}/build/Build/Products/Release"
+  local -r app_name="VimR.app"
+  local -r source_app="${build_products_path}/${app_name}"
+  local -r target_app="/Applications/${app_name}"
+
+  pushd "${project_root}" >/dev/null
+
+  echo "### Building local release (clean=${clean})..."
+
+  # Call the main build script with appropriate flags
+  # clean: user provided (default false)
+  # notarize: false (local dev)
+  # trust_plugins: true (skip validation)
+  # strip_symbols: false (optional, but faster for dev)
+  clean=${clean} notarize=false trust_plugins=true strip_symbols=false ./bin/build_vimr.sh
+
+  if [[ ! -d "${source_app}" ]]; then
+    echo "### Error: Built app not found at ${source_app}"
+    exit 1
+  fi
+
+  echo "### Installing to ${target_app}..."
+
+  # Gracefully quit running instance
+  if pgrep -f "VimR" >/dev/null; then
+    echo "### Quitting running VimR..."
+    osascript -e 'quit app "VimR"' || true
+    # Wait a moment for it to close, or force kill if stuck
+    sleep 1
+    pkill -f "VimR" || true
+  fi
+
+  # Need sudo for /Applications
+  echo "### You may be asked for sudo password to overwrite /Applications/VimR.app"
+
+  if [[ -d "${target_app}" ]]; then
+    sudo rm -rf "${target_app}"
+  fi
+
+  sudo cp -R "${source_app}" "${target_app}"
+
+  echo "### Successfully installed VimR to /Applications"
+  popd >/dev/null
+}
+
+main

--- a/bin/build_nvimserver.sh
+++ b/bin/build_nvimserver.sh
@@ -14,52 +14,62 @@ main() {
   pushd "$(dirname "${BASH_SOURCE[0]}")/.." >/dev/null
 
   local -r resources_folder="./NvimView/Sources/NvimView/Resources"
-  rm -rf "${resources_folder}/NvimServer"
-  rm -rf "${resources_folder}/runtime"
 
-  if [[ "${clean}" == true ]]; then
-    pushd ./Neovim >/dev/null
+  # Only clean/download if explicitly requested or if resources are missing
+  if [[ "${clean}" == true ]] || [[ ! -f "${resources_folder}/NvimServer" ]]; then
+    echo "### Preparing Neovim resources (clean=${clean})..."
+    rm -rf "${resources_folder}/NvimServer"
+    rm -rf "${resources_folder}/runtime"
+
+    if [[ "${clean}" == true ]]; then
+      pushd ./Neovim >/dev/null
       rm -rf .deps
       rm -rf build
       make distclean
-    popd >/dev/null
+      popd >/dev/null
+    fi
 
-    rm -rf "${resources_folder}/NvimServer"
-    rm -rf "${resources_folder}/runtime"
-  fi
+    if [[ "${for_dev}" == true ]]; then
 
-  if [[ "${for_dev}" == true ]]; then
+      ./bin/neovim/bin/build_neovim_for_dev.sh
 
-    ./bin/neovim/bin/build_neovim_for_dev.sh
-
-    pushd ./Neovim/build >/dev/null
-      local arch; arch="$(uname -m)"; readonly arch
+      pushd ./Neovim/build >/dev/null
+      local arch
+      arch="$(uname -m)"
+      readonly arch
       tar -xf "nvim-macos-${arch}.tar.gz"
-    popd >/dev/null
+      popd >/dev/null
 
-    cp "./Neovim/build/nvim-macos-${arch}/bin/nvim" "${resources_folder}/NvimServer"
-    cp -r "./Neovim/build/nvim-macos-${arch}/share/nvim/runtime" "${resources_folder}"
+      cp "./Neovim/build/nvim-macos-${arch}/bin/nvim" "${resources_folder}/NvimServer"
+      cp -r "./Neovim/build/nvim-macos-${arch}/share/nvim/runtime" "${resources_folder}"
 
-  else
+    else
 
-    local neovim_release; neovim_release=$(jq -r ".neovimRelease" ./bin/neovim/resources/buildInfo.json)
-    readonly neovim_release
+      local neovim_release
+      neovim_release=$(jq -r ".neovimRelease" ./bin/neovim/resources/buildInfo.json)
+      readonly neovim_release
 
-    pushd ./Neovim >/dev/null
+      pushd ./Neovim >/dev/null
       mkdir -p build
       pushd ./build >/dev/null
-        curl -LO "https://github.com/qvacua/vimr/releases/download/${neovim_release}/nvim-macos-universal.tar.bz"
-        tar -xf nvim-macos-universal.tar.bz
+      curl -LO "https://github.com/qvacua/vimr/releases/download/${neovim_release}/nvim-macos-universal.tar.bz"
+      tar -xf nvim-macos-universal.tar.bz
       popd >/dev/null
-    popd >/dev/null
+      popd >/dev/null
 
-    cp ./Neovim/build/nvim-macos-universal/bin/nvim "${resources_folder}/NvimServer"
-    cp -r ./Neovim/build/nvim-macos-universal/share/nvim/runtime "${resources_folder}"
+      cp ./Neovim/build/nvim-macos-universal/bin/nvim "${resources_folder}/NvimServer"
+      cp -r ./Neovim/build/nvim-macos-universal/share/nvim/runtime "${resources_folder}"
 
+    fi
+  else
+    echo "### Neovim resources found. Skipping download/build."
   fi
 
   # Copy VimR specific vim file to runtime/plugin folder
-  cp "${resources_folder}/com.qvacua.NvimView.vim" "${resources_folder}/runtime/plugin"
+  # Only copy if content changed to avoid updating timestamp and triggering Xcode rebuilds
+  if ! cmp -s "${resources_folder}/com.qvacua.NvimView.vim" "${resources_folder}/runtime/plugin/com.qvacua.NvimView.vim"; then
+    cp "${resources_folder}/com.qvacua.NvimView.vim" "${resources_folder}/runtime/plugin"
+  fi
 
   popd >/dev/null
 }


### PR DESCRIPTION
This commit improves the local development experience by addressing several build system inefficiencies:

1.  **Fix Incremental Builds**: Corrected a bug in `bin/build_vimr.sh` where the build directory was always deleted regardless of the `clean` flag. Incremental builds now work as expected.
2.  **Optimize Neovim Resources**: `bin/build_nvimserver.sh` now skips downloading/building Neovim resources if they already exist, saving significant time on subsequent builds.
3.  **Support Local Signing**: `bin/build_vimr.sh` now performs ad-hoc signing when `notarize=false`, enabling locally built Release versions to run on Apple Silicon without manual codesigning.
4.  **Simplify Plugin Validation**: Added `trust_plugins` flag to `bin/build_vimr.sh` to bypass interactive SwiftLint plugin validation prompts.
5.  **New Convenience Script**: Added `bin/build_and_install_local_release.sh` to build and install a local Release version to `/Applications` in one step.
6.  **Documentation**: Updated `README.md` with instructions for local builds.

Implemented by Gemini.

Since the original code contains mixed indent spaces, I formatted it with 2 spaces indention (which should be the original convention of VimR), so the diff will looks a bit scary, if viewed by ignoring spaces with https://github.com/qvacua/vimr/pull/1143/files?diff=split&w=1, the diff will be very clear.