### PR TITLE
Persist cleared shortcuts instead of restoring defaults

### DIFF
--- a/VimR/VimR/ShortcutsPref.swift
+++ b/VimR/VimR/ShortcutsPref.swift
@@ -21,7 +21,10 @@ final class ShortcutValueTransformer: ValueTransformer {
 
   /// Shortcut to Data
   override func reverseTransformedValue(_ value: Any?) -> Any? {
-    guard let value, let shortcut = value as? Shortcut else { return nil }
+    // When the user clears a shortcut, the value is nil.
+    // We want to store an empty shortcut instead of removing the key from UserDefaults
+    // so that the default value is not restored on the next launch.
+    let shortcut = (value as? Shortcut) ?? Shortcut(keyEquivalent: "")
     return try? NSKeyedArchiver.archivedData(withRootObject: shortcut, requiringSecureCoding: true)
   }
 }


### PR DESCRIPTION
Custom keyboard shortcuts cleared in Preferences would frustratingly revert to defaults after a restart. This happened because clearing a shortcut removed its UserDefaults key, causing the app to misinterpret it as "never set" on the next launch.

This fix ensures that clearing a shortcut stores an explicit "empty" value. This preserves the user's intent to disable the shortcut and prevents the default value from being restored.

Fixed by Gemini CLI.

This should close #537, #951, and #1050.