### PR TITLE
change markdown preview to inherit base colors from the active Neovim theme

### DIFF
--- a/VimR/VimR/CssUtils.swift
+++ b/VimR/VimR/CssUtils.swift
@@ -19,26 +19,22 @@ final class CssUtils {
         of: "{{ nvim-background-color }}",
         with: self.htmlColor(theme.cssBackgroundColor)
       )
-      .replacingOccurrences(of: "{{ nvim-a }}", with: self.htmlColor(theme.cssA))
+      .replacingOccurrences(of: "{{ nvim-link-color }}", with: self.htmlColor(theme.cssLinkColor))
       .replacingOccurrences(
-        of: "{{ nvim-hr-background-color }}",
-        with: self.htmlColor(theme.cssHrBorderBackgroundColor)
+        of: "{{ nvim-hr-color }}",
+        with: self.htmlColor(theme.cssHrColor)
       )
       .replacingOccurrences(
-        of: "{{ nvim-hr-border-bottom-color }}",
-        with: self.htmlColor(theme.cssHrBorderBottomColor)
-      )
-      .replacingOccurrences(
-        of: "{{ nvim-blockquote-border-left-color }}",
-        with: self.htmlColor(theme.cssBlockquoteBorderLeftColor)
+        of: "{{ nvim-blockquote-border-color }}",
+        with: self.htmlColor(theme.cssBlockquoteBorderColor)
       )
       .replacingOccurrences(
         of: "{{ nvim-blockquote-color }}",
         with: self.htmlColor(theme.cssBlockquoteColor)
       )
       .replacingOccurrences(
-        of: "{{ nvim-h2-border-bottom-color }}",
-        with: self.htmlColor(theme.cssH2BorderBottomColor)
+        of: "{{ nvim-h2-border-color }}",
+        with: self.htmlColor(theme.cssH2BorderColor)
       )
       .replacingOccurrences(of: "{{ nvim-h6-color }}", with: self.htmlColor(theme.cssH6Color))
       .replacingOccurrences(
@@ -46,6 +42,14 @@ final class CssUtils {
         with: self.htmlColor(theme.cssCodeBackgroundColor)
       )
       .replacingOccurrences(of: "{{ nvim-code-color }}", with: self.htmlColor(theme.cssCodeColor))
+      .replacingOccurrences(of: "{{ nvim-comment-color }}", with: self.htmlColor(theme.cssCommentColor))
+      .replacingOccurrences(of: "{{ nvim-string-color }}", with: self.htmlColor(theme.cssStringColor))
+      .replacingOccurrences(of: "{{ nvim-boolean-color }}", with: self.htmlColor(theme.cssBooleanColor))
+      .replacingOccurrences(of: "{{ nvim-number-color }}", with: self.htmlColor(theme.cssNumberColor))
+      .replacingOccurrences(of: "{{ nvim-statement-color }}", with: self.htmlColor(theme.cssStatementColor))
+      .replacingOccurrences(of: "{{ nvim-type-color }}", with: self.htmlColor(theme.cssTypeColor))
+      .replacingOccurrences(of: "{{ nvim-constant-color }}", with: self.htmlColor(theme.cssConstantColor))
+      .replacingOccurrences(of: "{{ nvim-special-color }}", with: self.htmlColor(theme.cssSpecialColor))
   }
 
   private static func htmlColor(_ color: NSColor) -> String { "#\(color.hex)" }

--- a/VimR/VimR/MainWindow+Delegates.swift
+++ b/VimR/VimR/MainWindow+Delegates.swift
@@ -127,6 +127,14 @@ extension MainWindow {
       "Directory", // a
       "Question", // blockquote foreground
       "CursorColumn", // code background and foreground
+      "Comment", // general comment style
+      "String", // string literals
+      "Boolean", // boolean literals
+      "Number", // number literals
+      "Statement", // control flow statements
+      "Type", // type names
+      "Constant", // constants
+      "Special" // special characters/keywords
     ]
 
     let map: [String: CellAttributes] = colorNames.reduce(into: [:]) { dict, colorName in
@@ -140,8 +148,12 @@ extension MainWindow {
       dict[colorName] = CellAttributes(withDict: name, with: self.neoVimView.defaultCellAttributes)
     }.compactMapValues { $0 }
 
-    if map.count == colorNames.count { return map }
-    else { return nil }
+    if map.count == colorNames.count {
+      return map
+    } else {
+      self.logger.warning("Could not get all theme colors, will use defaults for some.")
+      return map
+    }
   }
 }
 

--- a/VimR/VimR/Theme.swift
+++ b/VimR/VimR/Theme.swift
@@ -57,15 +57,23 @@ struct Theme: CustomStringConvertible, Sendable {
 
   var cssColor = NSColor(hex: "24292e")!
   var cssBackgroundColor = NSColor.white
-  var cssA = NSColor(hex: "0366d6")!
-  var cssHrBorderBackgroundColor = NSColor(hex: "dfe2e5")!
-  var cssHrBorderBottomColor = NSColor(hex: "eeeeee")!
-  var cssBlockquoteBorderLeftColor = NSColor(hex: "dfe2e5")!
+  var cssLinkColor = NSColor(hex: "0366d6")!
+  var cssHrColor = NSColor(hex: "dfe2e5")!
+  var cssBlockquoteBorderColor = NSColor(hex: "dfe2e5")!
   var cssBlockquoteColor = NSColor(hex: "6a737d")!
-  var cssH2BorderBottomColor = NSColor(hex: "eaecef")!
+  var cssH2BorderColor = NSColor(hex: "eaecef")!
   var cssH6Color = NSColor(hex: "6a737d")!
   var cssCodeColor = NSColor(hex: "24292e")!
   var cssCodeBackgroundColor = NSColor(hex: "1b1f23")!
+
+  var cssCommentColor = NSColor.darkGray
+  var cssStringColor = NSColor.brown
+  var cssBooleanColor = NSColor.purple
+  var cssNumberColor = NSColor.blue
+  var cssStatementColor = NSColor.systemTeal
+  var cssTypeColor = NSColor.systemGreen
+  var cssConstantColor = NSColor.systemRed
+  var cssSpecialColor = NSColor.systemOrange
 
   var description: String {
     "Theme<" +
@@ -98,25 +106,60 @@ struct Theme: CustomStringConvertible, Sendable {
     self.selectedTabBackground = nvimTheme.selectedTabBackground
     self.selectedTabForeground = nvimTheme.selectedTabForeground
 
+    self.cssColor = nvimTheme.foreground
+    self.cssBackgroundColor = nvimTheme.background
+    self.cssHrColor = nvimTheme.foreground.withAlphaComponent(0.2)
+    self.cssBlockquoteBorderColor = nvimTheme.foreground.withAlphaComponent(0.4)
+    self.cssH2BorderColor = nvimTheme.foreground.withAlphaComponent(0.2)
+    self.cssH6Color = nvimTheme.foreground.withAlphaComponent(0.7)
+
     self.updateCssColors(additionalColorDict)
   }
 
   private mutating func updateCssColors(_ colors: [String: CellAttributes]) {
-    guard let normal = colors["Normal"],
-          let directory = colors["Directory"],
-          let question = colors["Question"],
-          let cursorColumn = colors["CursorColumn"] else { return }
+    if let directory = colors["Directory"] {
+      self.cssLinkColor = NSColor(rgb: directory.effectiveForeground)
+    }
 
-    self.cssColor = NSColor(rgb: normal.effectiveForeground)
-    self.cssBackgroundColor = NSColor(rgb: normal.effectiveBackground)
-    self.cssA = NSColor(rgb: directory.effectiveForeground)
-    self.cssHrBorderBackgroundColor = NSColor(rgb: cursorColumn.effectiveForeground)
-    self.cssHrBorderBottomColor = NSColor(rgb: cursorColumn.effectiveBackground)
-    self.cssBlockquoteBorderLeftColor = NSColor(rgb: cursorColumn.effectiveForeground)
-    self.cssBlockquoteColor = NSColor(rgb: question.effectiveBackground)
-    self.cssH2BorderBottomColor = NSColor(rgb: cursorColumn.effectiveBackground)
-    self.cssH6Color = NSColor(rgb: normal.effectiveForeground)
-    self.cssCodeColor = NSColor(rgb: cursorColumn.effectiveForeground)
-    self.cssCodeBackgroundColor = NSColor(rgb: cursorColumn.effectiveBackground)
+    if let question = colors["Question"] {
+      self.cssBlockquoteColor = NSColor(rgb: question.effectiveForeground)
+    }
+
+    if let cursorColumn = colors["CursorColumn"] {
+      self.cssCodeColor = NSColor(rgb: cursorColumn.effectiveForeground)
+      self.cssCodeBackgroundColor = NSColor(rgb: cursorColumn.effectiveBackground)
+    }
+
+    if let comment = colors["Comment"] {
+      self.cssCommentColor = NSColor(rgb: comment.effectiveForeground)
+    }
+
+    if let string = colors["String"] {
+      self.cssStringColor = NSColor(rgb: string.effectiveForeground)
+    }
+
+    if let boolean = colors["Boolean"] {
+      self.cssBooleanColor = NSColor(rgb: boolean.effectiveForeground)
+    }
+
+    if let number = colors["Number"] {
+      self.cssNumberColor = NSColor(rgb: number.effectiveForeground)
+    }
+
+    if let statement = colors["Statement"] {
+      self.cssStatementColor = NSColor(rgb: statement.effectiveForeground)
+    }
+
+    if let type = colors["Type"] {
+      self.cssTypeColor = NSColor(rgb: type.effectiveForeground)
+    }
+
+    if let constant = colors["Constant"] {
+      self.cssConstantColor = NSColor(rgb: constant.effectiveForeground)
+    }
+
+    if let special = colors["Special"] {
+      self.cssSpecialColor = NSColor(rgb: special.effectiveForeground)
+    }
   }
 }

--- a/VimR/VimR/markdown/color-overrides.css
+++ b/VimR/VimR/markdown/color-overrides.css
@@ -1,15 +1,23 @@
 :root {
   --nvim-color: {{ nvim-color }};
   --nvim-background-color: {{ nvim-background-color }};
-  --nvim-a: {{ nvim-a }};
-  --nvim-hr-background-color: {{ nvim-hr-background-color }};
-  --nvim-hr-border-bottom-color: {{ nvim-hr-border-bottom-color }};
-  --nvim-blockquote-border-left-color: {{ nvim-blockquote-border-left-color }};
+  --nvim-link-color: {{ nvim-link-color }};
+  --nvim-hr-color: {{ nvim-hr-color }};
+  --nvim-blockquote-border-color: {{ nvim-blockquote-border-color }};
   --nvim-blockquote-color: {{ nvim-blockquote-color }};
-  --nvim-h2-border-bottom-color: {{ nvim-h2-border-bottom-color }};
+  --nvim-h2-border-color: {{ nvim-h2-border-color }};
   --nvim-h6-color: {{ nvim-h6-color }};
   --nvim-code-background-color: {{ nvim-code-background-color }};
   --nvim-code-color: {{ nvim-code-color }};
+
+  --nvim-comment-color: {{ nvim-comment-color }};
+  --nvim-string-color: {{ nvim-string-color }};
+  --nvim-boolean-color: {{ nvim-boolean-color }};
+  --nvim-number-color: {{ nvim-number-color }};
+  --nvim-statement-color: {{ nvim-statement-color }};
+  --nvim-type-color: {{ nvim-type-color }};
+  --nvim-constant-color: {{ nvim-constant-color }};
+  --nvim-special-color: {{ nvim-special-color }};
 }
 
 .markdown-body {
@@ -18,21 +26,21 @@
 }
 
 .markdown-body a {
-  color: var(--nvim-a);
+  color: var(--nvim-link-color);
 }
 
 .markdown-body hr {
-  background-color: var(--nvim-hr-background-color);
-  border-bottom-color: var(--nvim-hr-border-bottom-color);
+  background-color: var(--nvim-hr-color);
+  border-bottom-color: var(--nvim-hr-color);
 }
 
 .markdown-body blockquote {
-  border-left-color: var(--nvim-blockquote-border-left-color);
-  color: var(--nvim-blockquote-foreground);
+  border-left-color: var(--nvim-blockquote-border-color);
+  color: var(--nvim-blockquote-color);
 }
 
 .markdown-body h2 {
-  border-bottom-color: var(--nvim-border-bottom-color);
+  border-bottom-color: var(--nvim-h2-border-color);
 }
 
 .markdown-body h6 {
@@ -42,4 +50,43 @@
 .markdown-body pre {
   color: var(--nvim-code-color);
   background-color: var(--nvim-code-background-color);
+}
+
+/* New styles for additional highlight groups */
+code[class*="language-"] .token.comment,
+code[class*="language-"] .token.prolog,
+code[class*="language-"] .token.doctype,
+code[class*="language-"] .token.cdata {
+  color: var(--nvim-comment-color);
+}
+
+code[class*="language-"] .token.string {
+  color: var(--nvim-string-color);
+}
+
+code[class*="language-"] .token.boolean {
+  color: var(--nvim-boolean-color);
+}
+
+code[class*="language-"] .token.number {
+  color: var(--nvim-number-color);
+}
+
+code[class*="language-"] .token.keyword {
+  color: var(--nvim-statement-color);
+}
+
+code[class*="language-"] .token.function,
+code[class*="language-"] .token.class-name,
+code[class*="language-"] .token.tag {
+  color: var(--nvim-type-color);
+}
+
+code[class*="language-"] .token.constant {
+  color: var(--nvim-constant-color);
+}
+
+code[class*="language-"] .token.punctuation,
+code[class*="language-"] .token.operator {
+  color: var(--nvim-special-color);
 }

--- a/VimR/VimR/markdown/template.html
+++ b/VimR/VimR/markdown/template.html
@@ -3,10 +3,13 @@
 <head>
   <meta charset="UTF-8">
   <link rel="stylesheet" href="github-markdown.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism.min.css">
   <style>
     {{ css-overrides }}
   </style>
   <script src='https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js?config=TeX-MML-AM_CHTML' async></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/prism.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/plugins/autoloader/prism-autoloader.min.js"></script>
   <script>
     // Scrolling
     const sourceposRegex = /(\d+):(\d+)-(\d+):(\d+)/;
@@ -157,5 +160,6 @@
 </head>
 <body class="markdown-body">
 {{ body }}
+<script>Prism.highlightAll();</script>
 </body>
 </html>


### PR DESCRIPTION
Hey,

Thanks for this project, it's great.
I just wanted to share/add this PR to fix the markdown preview being white by default. Maybe this could be added as an option, but I'm not sure how to do that and wanted to start this as a PR

Related to #732 

Thank you

Changes:
Implements theme inheritance for the Markdown preview window, including syntax highlighting for code blocks.

 - The preview background, text, and other elements are now styled using the main colors from the active Neovim theme.
 - Code blocks are syntax-highlighted using Prism.js. The highlight colors are sourced from the corresponding Neovim highlight groups (Comment, String, Number, etc.).
 - The theme-loading mechanism has been refactored to be more resilient, ensuring the theme applies even if some highlight groups are not defined by the colorscheme.