### PR TITLE
Add remote socket support

### DIFF
--- a/NvimApi/Sources/NvimApi/MsgpackRpc.swift
+++ b/NvimApi/Sources/NvimApi/MsgpackRpc.swift
@@ -4,6 +4,7 @@
 import Foundation
 import MessagePack
 import os
+import Socket
 
 // Inspired by https://stackoverflow.com/a/76941591
 extension Pipe {
@@ -81,7 +82,44 @@ public actor MsgpackRpc {
     self.outPipe = outPipe
     self.errorPipe = errorPipe
 
-    try await self.startReading()
+    try await self.startReadingFromPipe()
+  }
+
+  /// Connect to an already-running neovim instance via a Unix domain socket
+  /// (the path neovim was started with via `--listen`).
+  public func run(socketPath: String) async throws {
+    let sock = try Socket.create(family: .unix, proto: .unix)
+    try sock.connect(to: socketPath)
+    self.socket = sock
+    try await self.startReadingFromSocket()
+  }
+
+  /// Connect to an already-running neovim instance via TCP (host:port).
+  public func run(host: String, port: Int32) async throws {
+    let sock = try Socket.create(family: .inet, type: .stream, proto: .tcp)
+    try sock.connect(to: host, port: port)
+    self.socket = sock
+    try await self.startReadingFromSocket()
+  }
+
+  /// Connect to a neovim `--listen` address. Accepts either a Unix socket path
+  /// (e.g. "/tmp/nvim.sock") or a TCP address (e.g. "localhost:6666").
+  public func run(address: String) async throws {
+    if let (host, port) = Self.parseTcpAddress(address) {
+      try await self.run(host: host, port: port)
+    } else {
+      try await self.run(socketPath: address)
+    }
+  }
+
+  /// Parses "host:port" into components. Returns nil if it's not a TCP address.
+  nonisolated static func parseTcpAddress(_ address: String) -> (host: String, port: Int32)? {
+    // URL needs a scheme to parse host/port correctly.
+    guard let url = URL(string: "tcp://\(address)"),
+          let host = url.host, !host.isEmpty,
+          let port = url.port, (1...65535).contains(port)
+    else { return nil }
+    return (host, Int32(port))
   }
 
   public func stop() {
@@ -104,7 +142,7 @@ public actor MsgpackRpc {
       ]
     )
 
-    try self.inPipe?.fileHandleForWriting.write(contentsOf: packed)
+    try self.writeData(packed)
   }
 
   public func request(
@@ -129,7 +167,7 @@ public actor MsgpackRpc {
       ]
     )
 
-    try self.inPipe?.fileHandleForWriting.write(contentsOf: packed)
+    try self.writeData(packed)
 
     if !expectsReturnValue {
       return .nilResponse(msgid)
@@ -151,15 +189,27 @@ public actor MsgpackRpc {
   private var inPipe: Pipe?
   private var outPipe: Pipe?
   private var errorPipe: Pipe?
+  private var socket: Socket?
 
   private var readingTask: Task<Void, any Swift.Error>?
 
   private var nextMsgid: UInt32 = 1
   private var pendingRequests = [UInt32: CheckedContinuation<Response, Never>]()
 
-  private func startReading() async throws {
+  /// Unified write: sends data through whichever transport is active.
+  private func writeData(_ data: Data) throws {
+    if let socket = self.socket {
+      try socket.write(from: data)
+    } else if let pipe = self.inPipe {
+      try pipe.fileHandleForWriting.write(contentsOf: data)
+    } else {
+      throw Error(msg: "No transport available for writing")
+    }
+  }
+
+  private func startReadingFromPipe() async throws {
     self.readingTask = Task.detached(priority: .high) {
-      dlog.debug("Start reading")
+      dlog.debug("Start reading (pipe)")
       guard let dataStream = await self.outPipe?.asyncData else {
         throw Error(msg: "Could not get the async data stream")
       }
@@ -184,7 +234,53 @@ public actor MsgpackRpc {
         }
       }
 
-      dlog.debug("End reading")
+      dlog.debug("End reading (pipe)")
+      await self.cleanUp()
+    }
+  }
+
+  private func startReadingFromSocket() async throws {
+    guard let socket = self.socket else {
+      throw Error(msg: "Socket not available for reading")
+    }
+    // Capture socket locally before entering the detached task to satisfy Sendable.
+    // BlueSocket is not Sendable but we guarantee exclusive read access from this single task.
+    nonisolated(unsafe) let sock = socket
+    self.readingTask = Task.detached(priority: .high) {
+      dlog.debug("Start reading (socket)")
+
+      var buffer = Data()
+      while !Task.isCancelled {
+        var chunk = Data()
+        let bytesRead: Int
+        do {
+          bytesRead = try sock.read(into: &chunk)
+        } catch {
+          if Task.isCancelled { break }
+          throw Error(msg: "Socket read error", cause: error)
+        }
+
+        if bytesRead == 0 {
+          // Connection closed by peer
+          break
+        }
+
+        buffer.append(chunk)
+
+        let (values, remainder) = try self.unpackAllWithRemainder(buffer)
+
+        if let remainder {
+          buffer = remainder
+        } else {
+          buffer.removeAll(keepingCapacity: true)
+        }
+
+        for value in values {
+          await self.processMessage(value)
+        }
+      }
+
+      dlog.debug("End reading (socket)")
       await self.cleanUp()
     }
   }
@@ -201,6 +297,7 @@ public actor MsgpackRpc {
     self.readingTask?.cancel()
     self.readingTask = nil
 
+    // Clean up pipe transport
     self.inPipe?.fileHandleForReading.readabilityHandler = nil
     self.inPipe?.fileHandleForWriting.closeFile()
     self.outPipe?.fileHandleForReading.closeFile()
@@ -209,6 +306,10 @@ public actor MsgpackRpc {
     self.inPipe = nil
     self.outPipe = nil
     self.errorPipe = nil
+
+    // Clean up socket transport
+    self.socket?.close()
+    self.socket = nil
 
     self.streamContinuation.finish()
     for (msgid, continuation) in self.pendingRequests {

--- a/NvimApi/Sources/NvimApi/NvimApi.swift
+++ b/NvimApi/Sources/NvimApi/NvimApi.swift
@@ -32,6 +32,16 @@ public actor NvimApi {
     try await self.msgpackRpc.run(inPipe: inPipe, outPipe: outPipe, errorPipe: errorPipe)
   }
 
+  /// Connect to an already-running neovim instance via its Unix domain socket.
+  public func run(socketPath: String) async throws {
+    try await self.msgpackRpc.run(socketPath: socketPath)
+  }
+
+  /// Connect to a neovim `--listen` address (Unix socket path or host:port).
+  public func run(address: String) async throws {
+    try await self.msgpackRpc.run(address: address)
+  }
+
   public func stop() async { await self.msgpackRpc.stop() }
 
   public func isBlocked() async -> Result<Bool, NvimApi.Error> {

--- a/NvimApi/Sources/NvimApi/NvimApiSync.swift
+++ b/NvimApi/Sources/NvimApi/NvimApiSync.swift
@@ -5,20 +5,33 @@ import Socket
 
 /// Only supports requests
 public class NvimApiSync: @unchecked Sendable {
-  public init() {
-    // We know it will succeed
-    // swiftlint:disable:next force_try
-    self.socket = try! Socket.create(family: .unix, proto: .unix)
-  }
+  public init() {}
 
   public func run(socketPath: String) throws {
-    try self.socket.connect(to: socketPath)
+    let sock = try Socket.create(family: .unix, proto: .unix)
+    try sock.connect(to: socketPath)
+    self.socket = sock
+  }
+
+  public func run(host: String, port: Int32) throws {
+    let sock = try Socket.create(family: .inet, type: .stream, proto: .tcp)
+    try sock.connect(to: host, port: port)
+    self.socket = sock
+  }
+
+  /// Connect to a neovim `--listen` address (Unix socket path or host:port).
+  public func run(address: String) throws {
+    if let (host, port) = MsgpackRpc.parseTcpAddress(address) {
+      try self.run(host: host, port: port)
+    } else {
+      try self.run(socketPath: address)
+    }
   }
 
   public func stop() {
     self.lock.lock()
     defer { lock.unlock() }
-    self.socket.close()
+    self.socket?.close()
   }
 
   public func sendRequest(
@@ -40,10 +53,13 @@ public class NvimApiSync: @unchecked Sendable {
     let data = MessagePack.pack(.array(request))
 
     do {
-      try self.socket.write(from: data)
+      guard let socket = self.socket else {
+        return .failure(.exception(message: "NvimApiSync: not connected"))
+      }
+      try socket.write(from: data)
 
       var response = Data()
-      _ = try self.socket.read(into: &response)
+      _ = try socket.read(into: &response)
 
       let decoded = try MessagePack.unpack(response)
       guard case let .array(unpacked) = decoded.value,
@@ -88,7 +104,7 @@ public class NvimApiSync: @unchecked Sendable {
     return nil
   }
 
-  private let socket: Socket
+  private var socket: Socket?
   private var msgId: UInt32 = 0
   private let lock = OSAllocatedUnfairLock()
 }

--- a/NvimView/Sources/NvimView/NvimProcess.swift
+++ b/NvimView/Sources/NvimView/NvimProcess.swift
@@ -41,10 +41,10 @@ final class NvimProcess {
     try self.launchNvimUsingLoginShellEnv()
   }
 
-  /// Launch nvim in headless mode with --listen only (no --embed, no stdio pipes).
-  /// Used for socket-launch mode: we connect to the socket afterwards.
-  func runLocalServerHeadless() throws {
-    try self.launchNvimHeadless()
+  /// Launch nvim with --embed --listen for socket-launch mode.
+  /// nvim blocks its event loop until nvim_ui_attach is called on the socket.
+  func runLocalServerEmbedSocket() throws {
+    try self.launchNvimEmbedSocket()
   }
 
   func quit() {
@@ -63,15 +63,17 @@ final class NvimProcess {
     self.nvimServerProc?.terminate()
   }
 
-  private func launchNvimHeadless() throws {
+  private func launchNvimEmbedSocket() throws {
     var env = self.envDict
 
     let process = Process()
-    // Redirect stdio to /dev/null — we connect via the --listen socket, not pipes.
-    let devNull = FileHandle.nullDevice
-    process.standardInput = devNull
-    process.standardOutput = devNull
-    process.standardError = devNull
+    // Use a pipe for stdin so nvim doesn't read EOF from /dev/null.
+    // With --embed --listen, nvim blocks its event loop waiting for nvim_ui_attach
+    // on the socket rather than driving the UI via stdio, so this pipe is never
+    // written to — it just keeps stdin open.
+    process.standardInput = Pipe()
+    process.standardOutput = Pipe()
+    process.standardError = Pipe()
     process.currentDirectoryPath = self.cwd.path
     process.qualityOfService = .userInteractive
 
@@ -83,27 +85,20 @@ final class NvimProcess {
       process.launchPath = launchPath
     }
     process.environment = env
-    // --headless (not --embed) is intentional here. The nvim docs say
-    // "UI embedders that want the UI protocol on a socket must pass --embed --listen".
-    // That pattern applies when the parent process drives nvim via stdio RPC AND
-    // also wants a socket — which is what pipe mode (launchNvimUsingLoginShellEnv)
-    // does with ["--embed", "--listen", ...].
-    //
-    // This socket-launch mode is different: VimR is NOT the stdio parent.
-    // nvim must run independently with its own event loop. Using --embed here
-    // would cause nvim to exit immediately when it reads EOF on the /dev/null stdin.
-    // --headless starts nvim without a TUI but with a live event loop, creates the
-    // socket, and keeps running until explicitly quit — exactly what we need.
-    process.arguments = ["--headless", "--listen", self.pipeUrl.path] + self.nvimArgs
+    // --embed --listen: nvim starts without a TUI and blocks its event loop until
+    // nvim_ui_attach is called on the socket. This means we don't need to poll for
+    // socket creation — connecting and calling nvim_ui_attach is sufficient
+    // synchronisation.
+    process.arguments = ["--embed", "--listen", self.pipeUrl.path] + self.nvimArgs
 
-    dlog.debug("Servername (headless): \(self.pipeUrl.path)")
+    dlog.debug("Servername (socket-launch): \(self.pipeUrl.path)")
     dlog.debug(
-      "Launching NvimServer (headless) \(String(describing: process.launchPath)) with args: \(String(describing: process.arguments))"
+      "Launching NvimServer (socket-launch) \(String(describing: process.launchPath)) with args: \(String(describing: process.arguments))"
     )
     do {
       try process.run()
     } catch {
-      throw NvimApi.Error.exception(message: "Could not run neovim process (headless).")
+      throw NvimApi.Error.exception(message: "Could not run neovim process (socket-launch).")
     }
 
     self.nvimServerProc = process

--- a/NvimView/Sources/NvimView/NvimProcess.swift
+++ b/NvimView/Sources/NvimView/NvimProcess.swift
@@ -41,6 +41,12 @@ final class NvimProcess {
     try self.launchNvimUsingLoginShellEnv()
   }
 
+  /// Launch nvim in headless mode with --listen only (no --embed, no stdio pipes).
+  /// Used for socket-launch mode: we connect to the socket afterwards.
+  func runLocalServerHeadless() throws {
+    try self.launchNvimHeadless()
+  }
+
   func quit() {
     self.nvimServerProc?.waitUntilExit()
     dlog.debug("NvimServer \(self.uuid) exited successfully.")
@@ -55,6 +61,44 @@ final class NvimProcess {
   private func forceExitNvimServer() {
     self.nvimServerProc?.interrupt()
     self.nvimServerProc?.terminate()
+  }
+
+  private func launchNvimHeadless() throws {
+    var env = self.envDict
+
+    let process = Process()
+    // Redirect stdio to /dev/null — we connect via the --listen socket, not pipes.
+    let devNull = FileHandle.nullDevice
+    process.standardInput = devNull
+    process.standardOutput = devNull
+    process.standardError = devNull
+    process.currentDirectoryPath = self.cwd.path
+    process.qualityOfService = .userInteractive
+
+    if self.nvimBinary != "", FileManager.default.fileExists(atPath: self.nvimBinary) {
+      process.launchPath = self.nvimBinary
+    } else {
+      env["VIMRUNTIME"] = Bundle.module.url(forResource: "runtime", withExtension: nil)!.path
+      let launchPath = Bundle.module.url(forResource: "NvimServer", withExtension: nil)!.path
+      process.launchPath = launchPath
+    }
+    process.environment = env
+    // --headless runs nvim without a TUI but with a full event loop, so the
+    // --listen socket is created and kept alive. We then connect via socket.
+    // (--embed would exit immediately because stdin is /dev/null.)
+    process.arguments = ["--headless", "--listen", self.pipeUrl.path] + self.nvimArgs
+
+    dlog.debug("Servername (headless): \(self.pipeUrl.path)")
+    dlog.debug(
+      "Launching NvimServer (headless) \(String(describing: process.launchPath)) with args: \(String(describing: process.arguments))"
+    )
+    do {
+      try process.run()
+    } catch {
+      throw NvimApi.Error.exception(message: "Could not run neovim process (headless).")
+    }
+
+    self.nvimServerProc = process
   }
 
   private func launchNvimUsingLoginShellEnv() throws -> (Pipe, Pipe, Pipe) {

--- a/NvimView/Sources/NvimView/NvimProcess.swift
+++ b/NvimView/Sources/NvimView/NvimProcess.swift
@@ -83,9 +83,17 @@ final class NvimProcess {
       process.launchPath = launchPath
     }
     process.environment = env
-    // --headless runs nvim without a TUI but with a full event loop, so the
-    // --listen socket is created and kept alive. We then connect via socket.
-    // (--embed would exit immediately because stdin is /dev/null.)
+    // --headless (not --embed) is intentional here. The nvim docs say
+    // "UI embedders that want the UI protocol on a socket must pass --embed --listen".
+    // That pattern applies when the parent process drives nvim via stdio RPC AND
+    // also wants a socket — which is what pipe mode (launchNvimUsingLoginShellEnv)
+    // does with ["--embed", "--listen", ...].
+    //
+    // This socket-launch mode is different: VimR is NOT the stdio parent.
+    // nvim must run independently with its own event loop. Using --embed here
+    // would cause nvim to exit immediately when it reads EOF on the /dev/null stdin.
+    // --headless starts nvim without a TUI but with a live event loop, creates the
+    // socket, and keeps running until explicitly quit — exactly what we need.
     process.arguments = ["--headless", "--listen", self.pipeUrl.path] + self.nvimArgs
 
     dlog.debug("Servername (headless): \(self.pipeUrl.path)")

--- a/NvimView/Sources/NvimView/NvimView+Api.swift
+++ b/NvimView/Sources/NvimView/NvimView+Api.swift
@@ -25,6 +25,11 @@ extension Collection where Element: Sendable {
 }
 
 public extension NvimView {
+  /// True when this view is connected to an already-running neovim instance
+  /// (via "Connect to Running Neovim"). False when VimR launched the process
+  /// itself (pipe or socket-launch mode).
+  var isAttachedToRunningNvim: Bool { self.remoteSocketPath != nil }
+
   func stop() async {
     if self.stopped {
       dlog.debug("Bridge already stopped.")
@@ -32,7 +37,21 @@ public extension NvimView {
     }
 
     self.stopped = true
-    self.nvimProc.quit()
+
+    if self.remoteSocketPath != nil {
+      // We connected to an already-running nvim — clear the gui flag then
+      // detach the UI without killing the server process.
+      _ = await self.api.nvimExecLua(
+        code: "vim.g.gui_vimr = nil",
+        args: [],
+        errWhenBlocked: false
+      )
+      _ = await self.api.nvimUiDetach()
+      dlog.debug("UI detached from remote Nvim.")
+    } else {
+      // We spawned this nvim (pipe or socket-launch) — let it exit normally.
+      self.nvimProc.quit()
+    }
 
     self.apiSync.stop()
     await self.api.stop()

--- a/NvimView/Sources/NvimView/NvimView+RemoteOptions.swift
+++ b/NvimView/Sources/NvimView/NvimView+RemoteOptions.swift
@@ -91,19 +91,24 @@ extension NvimView {
       return
     }
 
-    guard let newFont = FontUtils.font(fromVimFontSpec: fontSpec) else {
-      self.logger.error("Invalid specification for guifont '\(fontSpec)'")
-
-      self.signalError(code: 596, message: "Invalid font(s): guifont=\(fontSpec)")
-      self.signalRemoteOptionChange(RemoteOption.fromFont(self.font, forWideFont: wideFlag))
-      return
+    // guifont may be a comma-separated fallback list (neovide-style) or a single
+    // VimR-style Name:hSize spec. Try each candidate in order.
+    let candidates = fontSpec.components(separatedBy: ",").map { $0.trimmingCharacters(in: .whitespaces) }
+    for candidate in candidates {
+      if let newFont = FontUtils.font(fromVimFontSpec: candidate) {
+        self.font = newFont
+        // Cell size likely changed, do a resize.
+        self.resizeNeoVimUi(to: self.frame.size)
+        self.markForRenderWholeView()
+        self.delegate?.nextEvent(.guifontChanged(newFont))
+        return
+      }
     }
 
-    self.font = newFont
-    // Cell size likely changed, do a resize.
-    self.resizeNeoVimUi(to: self.frame.size)
-    self.markForRenderWholeView()
-    self.delegate?.nextEvent(.guifontChanged(newFont))
+    // No candidate matched — log quietly and push back the current font so nvim
+    // is in sync. Don't surface E596 to the user for unsupported font spec formats.
+    self.logger.error("No usable font in guifont spec '\(fontSpec)' — keeping current font")
+    self.signalRemoteOptionChange(RemoteOption.fromFont(self.font, forWideFont: wideFlag))
   }
 }
 

--- a/NvimView/Sources/NvimView/NvimView+Types.swift
+++ b/NvimView/Sources/NvimView/NvimView+Types.swift
@@ -27,6 +27,11 @@ public extension NvimView {
     var nvimArgs: [String]?
     var additionalEnvs: [String: String]
     var sourceFiles: [URL]
+    /// When set, connect to an already-running neovim at this Unix socket path
+    /// instead of spawning a child process.
+    var remoteSocketPath: String?
+    /// When true, launch nvim with --listen and connect via socket instead of stdio pipes.
+    var useSocketConnection: Bool
 
     public init(
       usesCustomTabBar: Bool,
@@ -35,7 +40,9 @@ public extension NvimView {
       nvimBinary: String,
       nvimArgs: [String]?,
       additionalEnvs: [String: String],
-      sourceFiles: [URL]
+      sourceFiles: [URL],
+      remoteSocketPath: String? = nil,
+      useSocketConnection: Bool = false
     ) {
       self.usesCustomTabBar = usesCustomTabBar
       self.useInteractiveZsh = useInteractiveZsh
@@ -44,6 +51,8 @@ public extension NvimView {
       self.nvimArgs = nvimArgs
       self.additionalEnvs = additionalEnvs
       self.sourceFiles = sourceFiles
+      self.remoteSocketPath = remoteSocketPath
+      self.useSocketConnection = useSocketConnection
     }
   }
 

--- a/NvimView/Sources/NvimView/NvimView.swift
+++ b/NvimView/Sources/NvimView/NvimView.swift
@@ -382,30 +382,20 @@ public final class NvimView: NSView,
 
   // MARK: - Shared Nvim Setup
 
-  /// Lua chunk that defines the GetHiColor helper and sets vim.g.gui_vimr.
-  /// Used by all connection modes before any autocmds are registered.
-  /// Takes no args (called with `...` = empty).
+  /// Lua chunk that defines the GetHiColor helper, sets vim.g.gui_vimr, and registers
+  /// the ColorScheme autocmd. Receives the RPC channel as the first vararg.
+  /// By including ColorScheme here it is registered early (before attachUi / VimEnter)
+  /// in pipe mode, so the initial colorscheme event fires naturally — matching the old
+  /// single-block vimscript approach.
   private static let preambleLua = """
+    local ch = select(1, ...)
     vim.g.gui_vimr = 1
     _G.GetHiColor = function(hlID, component)
       local color = vim.fn.synIDattr(vim.fn.synIDtrans(vim.fn.hlID(hlID)), component)
       if color == nil or color == '' then return -1 end
       return tonumber(color:sub(2), 16) or -1
     end
-    """
-
-  /// Lua chunk that registers all autocmds VimR needs.
-  /// Receives the RPC channel as the first vararg (`select(1, ...)`).
-  /// Separated from the preamble so that pipe mode can register these
-  /// during vimenter (after the blocking rpcrequest handshake) without
-  /// double-registering.
-  private static let autocmdLua = """
-    local ch = select(1, ...)
     local augroup = vim.api.nvim_create_augroup('VimRBridge', { clear = true })
-    vim.api.nvim_create_autocmd('VimLeave', {
-      group = augroup,
-      callback = function() vim.rpcnotify(ch, 'autocommand', 'vimleave') end,
-    })
     vim.api.nvim_create_autocmd('ColorScheme', {
       group = augroup,
       callback = function()
@@ -417,6 +407,17 @@ public final class NvimView: NSView,
           GetHiColor('Tabline', 'bg'), GetHiColor('Tabline', 'fg'),
           GetHiColor('TablineSel', 'bg'), GetHiColor('TablineSel', 'fg'))
       end,
+    })
+    """
+
+  /// Lua chunk that registers the remaining autocmds VimR needs (everything except
+  /// ColorScheme, which is in preambleLua). Receives the RPC channel as the first vararg.
+  private static let autocmdLua = """
+    local ch = select(1, ...)
+    local augroup = vim.api.nvim_create_augroup('VimRBridge', { clear = false })
+    vim.api.nvim_create_autocmd('VimLeave', {
+      group = augroup,
+      callback = function() vim.rpcnotify(ch, 'autocommand', 'vimleave') end,
     })
     vim.api.nvim_create_autocmd('BufWinEnter', {
       group = augroup,
@@ -474,7 +475,7 @@ public final class NvimView: NSView,
   private func runCommonNvimSetup(channel: Int32, includePreamble: Bool) async throws {
     if includePreamble {
       _ = try await self.api.nvimExecLua(
-        code: Self.preambleLua, args: [], errWhenBlocked: false
+        code: Self.preambleLua, args: [.int(Int64(channel))], errWhenBlocked: false
       ).get()
     }
 
@@ -593,8 +594,8 @@ public final class NvimView: NSView,
   }
 
   /// Handles the blocking "vimenter" rpcrequest during the embedded pipe startup sequence.
-  /// The preamble (GetHiColor etc) was already exec'd by launchNvim(), so we only
-  /// register the autocmds and do subscribe/source/ginit here.
+  /// The preamble and autocmds were already registered by launchNvim(), so we only
+  /// do subscribe/source/ginit here and re-register autocmds (idempotent via clear=true).
   private func doSetupForVimenterAndSendResponse(forMsgid msgid: UInt32) async {
     do {
       let channel = try await self.getChannelAndVerifyVersion()
@@ -629,16 +630,18 @@ public final class NvimView: NSView,
       let channel = try await self.getChannelAndVerifyVersion()
       dlog.debug("Version fine")
 
-      // Only the preamble and VimEnter hooks here. The full autocmd set is
-      // registered later in doSetupForVimenterAndSendResponse() when the
-      // blocking rpcrequest arrives.
+      // Preamble: registers GetHiColor, gui_vimr, and the ColorScheme autocmd.
+      // ColorScheme is registered here so it fires naturally during VimEnter,
+      // matching the original single-block vimscript approach.
       _ = try await self.api.nvimExecLua(
-        code: Self.preambleLua, args: [], errWhenBlocked: false
+        code: Self.preambleLua, args: [.int(Int64(channel))], errWhenBlocked: false
       ).get()
+
+      // VimEnter hooks: notify + blocking rpcrequest handled in doSetupForVimenterAndSendResponse.
       _ = try await self.api.nvimExecLua(
         code: """
           local ch = select(1, ...)
-          local augroup = vim.api.nvim_create_augroup('VimRBridge', { clear = true })
+          local augroup = vim.api.nvim_create_augroup('VimRBridge', { clear = false })
           vim.api.nvim_create_autocmd('VimEnter', {
             group = augroup, once = true,
             callback = function() vim.rpcnotify(ch, 'autocommand', 'vimenter') end,

--- a/NvimView/Sources/NvimView/NvimView.swift
+++ b/NvimView/Sources/NvimView/NvimView.swift
@@ -586,26 +586,79 @@ public final class NvimView: NSView,
     dlog.debug("Connected to running Nvim")
   }
 
-  /// Launch a local nvim with --listen, then connect via socket (no stdio pipes).
+  /// Launch a local nvim with --embed --listen, then connect via socket.
+  /// --embed makes nvim block its event loop waiting for nvim_ui_attach, but the
+  /// socket file is created during nvim's startup before that blocking point, so
+  /// we wait for the file to appear before connecting.
   private func launchNvimAndConnectViaSocket(_ size: Size) async {
     dlog.debug("Starting Nvim (socket-launch mode)")
 
     do {
-      try self.nvimProc.runLocalServerHeadless()
+      try self.nvimProc.runLocalServerEmbedSocket()
     } catch {
       self.dieWithFatalError(description: "Could not launch Nvim: \(error)")
       return
     }
 
-    // Give nvim a moment to create the socket
     let socketPath = self.nvimProc.pipeUrl.path
-    for _ in 0..<50 {
-      if FileManager.default.fileExists(atPath: socketPath) { break }
-      try? await Task.sleep(nanoseconds: 100_000_000) // 100ms
+    do {
+      try await waitForFile(atPath: socketPath, timeout: 5.0)
+    } catch {
+      self.dieWithFatalError(description: "Nvim socket did not appear at \(socketPath): \(error)")
+      return
     }
 
     await self.connectToRunningNvim(address: socketPath, size: size)
     dlog.debug("Launched Nvim (socket-launch mode)")
+  }
+
+  /// Waits for a file to appear at `path`, checking via a `DispatchSourceFileSystemObject`
+  /// on the parent directory. Falls back to a timeout error if the file hasn't appeared
+  /// within `timeout` seconds.
+  private func waitForFile(atPath path: String, timeout: TimeInterval) async throws {
+    guard !FileManager.default.fileExists(atPath: path) else { return }
+
+    let directory = (path as NSString).deletingLastPathComponent
+    let dirFd = Darwin.open(directory, O_EVTONLY)
+    guard dirFd >= 0 else {
+      throw NvimApi.Error.exception(message: "Could not open directory for monitoring: \(directory)")
+    }
+
+    try await withThrowingTaskGroup(of: Void.self) { group in
+      // Watcher task: resolves as soon as the file appears
+      group.addTask {
+        await withCheckedContinuation { (cont: CheckedContinuation<Void, Never>) in
+          let source = DispatchSource.makeFileSystemObjectSource(
+            fileDescriptor: dirFd,
+            eventMask: .write,
+            queue: .global()
+          )
+          source.setEventHandler {
+            if FileManager.default.fileExists(atPath: path) {
+              source.cancel()
+              cont.resume()
+            }
+          }
+          source.setCancelHandler { close(dirFd) }
+          source.resume()
+          // Check once immediately in case it appeared before the source was armed
+          if FileManager.default.fileExists(atPath: path) {
+            source.cancel()
+            cont.resume()
+          }
+        }
+      }
+
+      // Timeout task
+      group.addTask {
+        try await Task.sleep(nanoseconds: UInt64(timeout * 1_000_000_000))
+        throw NvimApi.Error.exception(message: "Timed out waiting for socket at \(path)")
+      }
+
+      // First to finish wins; cancel the other
+      try await group.next()
+      group.cancelAll()
+    }
   }
 
   /// Handles the blocking "vimenter" rpcrequest during the embedded pipe startup sequence.

--- a/NvimView/Sources/NvimView/NvimView.swift
+++ b/NvimView/Sources/NvimView/NvimView.swift
@@ -488,33 +488,48 @@ public final class NvimView: NSView,
       .nvimSubscribe(event: NvimView.rpcEventName, expectsReturnValue: false).get()
 
     for url in self.sourceFileUrls {
-      _ = try await self.api.nvimExecLua(
-        code: "vim.cmd.source(select(1, ...))",
-        args: [.string(url.path)],
-        errWhenBlocked: false
-      ).get()
+      if self.remoteSocketPath != nil {
+        // Remote nvim can't access paths in the local app bundle, so read the
+        // file content here and ship it over the RPC channel.
+        let content = try String(contentsOf: url, encoding: .utf8)
+        _ = try await self.api.nvimExecLua(
+          code: "vim.api.nvim_exec2(select(1, ...), {})",
+          args: [.string(content)],
+          errWhenBlocked: false
+        ).get()
+      } else {
+        _ = try await self.api.nvimExecLua(
+          code: "vim.cmd.source(select(1, ...))",
+          args: [.string(url.path)],
+          errWhenBlocked: false
+        ).get()
+      }
     }
 
-    let ginitVimPath = FileManager.default
-      .homeDirectoryForCurrentUser
-      .appendingPathComponent(".config/nvim/ginit.vim").path
-    let ginitLuaPath = FileManager.default
-      .homeDirectoryForCurrentUser
-      .appendingPathComponent(".config/nvim/ginit.lua").path
-    if FileManager.default.fileExists(atPath: ginitLuaPath) {
-      dlog.debug("Source'ing ginit.lua")
-      _ = try await self.api.nvimExecLua(
-        code: "vim.cmd.source(select(1, ...))",
-        args: [.string(ginitLuaPath)],
-        errWhenBlocked: false
-      ).get()
-    } else if FileManager.default.fileExists(atPath: ginitVimPath) {
-      dlog.debug("Source'ing ginit.vim")
-      _ = try await self.api.nvimExecLua(
-        code: "vim.cmd.source(select(1, ...))",
-        args: [.string(ginitVimPath)],
-        errWhenBlocked: false
-      ).get()
+    // Skip ginit sourcing when attached to a remote nvim — the remote process
+    // has already sourced its own ginit on startup.
+    if self.remoteSocketPath == nil {
+      let ginitVimPath = FileManager.default
+        .homeDirectoryForCurrentUser
+        .appendingPathComponent(".config/nvim/ginit.vim").path
+      let ginitLuaPath = FileManager.default
+        .homeDirectoryForCurrentUser
+        .appendingPathComponent(".config/nvim/ginit.lua").path
+      if FileManager.default.fileExists(atPath: ginitLuaPath) {
+        dlog.debug("Source'ing ginit.lua")
+        _ = try await self.api.nvimExecLua(
+          code: "vim.cmd.source(select(1, ...))",
+          args: [.string(ginitLuaPath)],
+          errWhenBlocked: false
+        ).get()
+      } else if FileManager.default.fileExists(atPath: ginitVimPath) {
+        dlog.debug("Source'ing ginit.vim")
+        _ = try await self.api.nvimExecLua(
+          code: "vim.cmd.source(select(1, ...))",
+          args: [.string(ginitVimPath)],
+          errWhenBlocked: false
+        ).get()
+      }
     }
   }
 

--- a/NvimView/Sources/NvimView/NvimView.swift
+++ b/NvimView/Sources/NvimView/NvimView.swift
@@ -164,6 +164,8 @@ public final class NvimView: NSView,
       usesLigatures: self.usesLigatures
     )
     self.nvimProc = NvimProcess(uuid: self.uuid, config: config)
+    self.remoteSocketPath = config.remoteSocketPath
+    self.useSocketConnection = config.useSocketConnection
 
     self.sourceFileUrls = config.sourceFiles
 
@@ -270,6 +272,8 @@ public final class NvimView: NSView,
   var markedText: String?
 
   let sourceFileUrls: [URL]
+  let remoteSocketPath: String?
+  let useSocketConnection: Bool
 
   var tabEntries = [TabEntry]()
 
@@ -303,7 +307,15 @@ public final class NvimView: NSView,
   
   private func runBridge() {
     Task(priority: .high) {
-      await self.launchNvim(self.discreteSize(size: frame.size))
+      let size = self.discreteSize(size: frame.size)
+
+      if let socketPath = self.remoteSocketPath {
+        await self.connectToRunningNvim(address: socketPath, size: size)
+      } else if self.useSocketConnection {
+        await self.launchNvimAndConnectViaSocket(size)
+      } else {
+        await self.launchNvim(size)
+      }
 
       let stream = await self.api.msgpackRawStream
       for await msg in stream {
@@ -368,52 +380,232 @@ public final class NvimView: NSView,
     }
   }
 
+  // MARK: - Shared Nvim Setup
+
+  /// Lua chunk that defines the GetHiColor helper and sets vim.g.gui_vimr.
+  /// Used by all connection modes before any autocmds are registered.
+  /// Takes no args (called with `...` = empty).
+  private static let preambleLua = """
+    vim.g.gui_vimr = 1
+    _G.GetHiColor = function(hlID, component)
+      local color = vim.fn.synIDattr(vim.fn.synIDtrans(vim.fn.hlID(hlID)), component)
+      if color == nil or color == '' then return -1 end
+      return tonumber(color:sub(2), 16) or -1
+    end
+    """
+
+  /// Lua chunk that registers all autocmds VimR needs.
+  /// Receives the RPC channel as the first vararg (`select(1, ...)`).
+  /// Separated from the preamble so that pipe mode can register these
+  /// during vimenter (after the blocking rpcrequest handshake) without
+  /// double-registering.
+  private static let autocmdLua = """
+    local ch = select(1, ...)
+    local augroup = vim.api.nvim_create_augroup('VimRBridge', { clear = true })
+    vim.api.nvim_create_autocmd('VimLeave', {
+      group = augroup,
+      callback = function() vim.rpcnotify(ch, 'autocommand', 'vimleave') end,
+    })
+    vim.api.nvim_create_autocmd('ColorScheme', {
+      group = augroup,
+      callback = function()
+        vim.rpcnotify(ch, 'autocommand', 'colorscheme',
+          GetHiColor('Normal', 'fg'), GetHiColor('Normal', 'bg'),
+          GetHiColor('Visual', 'fg'), GetHiColor('Visual', 'bg'),
+          GetHiColor('Directory', 'fg'),
+          GetHiColor('TablineFill', 'bg'), GetHiColor('TablineFill', 'fg'),
+          GetHiColor('Tabline', 'bg'), GetHiColor('Tabline', 'fg'),
+          GetHiColor('TablineSel', 'bg'), GetHiColor('TablineSel', 'fg'))
+      end,
+    })
+    vim.api.nvim_create_autocmd('BufWinEnter', {
+      group = augroup,
+      callback = function(ev) vim.rpcnotify(ch, 'autocommand', 'bufwinenter', ev.buf) end,
+    })
+    vim.api.nvim_create_autocmd('BufWinLeave', {
+      group = augroup,
+      callback = function(ev) vim.rpcnotify(ch, 'autocommand', 'bufwinleave', ev.buf) end,
+    })
+    vim.api.nvim_create_autocmd('TabEnter', {
+      group = augroup,
+      callback = function(ev) vim.rpcnotify(ch, 'autocommand', 'tabenter', ev.buf) end,
+    })
+    vim.api.nvim_create_autocmd('BufWritePost', {
+      group = augroup,
+      callback = function(ev) vim.rpcnotify(ch, 'autocommand', 'bufwritepost', ev.buf) end,
+    })
+    vim.api.nvim_create_autocmd('BufEnter', {
+      group = augroup,
+      callback = function(ev) vim.rpcnotify(ch, 'autocommand', 'bufenter', ev.buf) end,
+    })
+    vim.api.nvim_create_autocmd('DirChanged', {
+      group = augroup,
+      callback = function(ev) vim.rpcnotify(ch, 'autocommand', 'dirchanged', ev.file) end,
+    })
+    vim.api.nvim_create_autocmd('BufModifiedSet', {
+      group = augroup,
+      callback = function(ev)
+        local info = vim.fn.getbufinfo(ev.buf)
+        local changed = info and info[1] and info[1].changed or 0
+        vim.rpcnotify(ch, 'autocommand', 'bufmodifiedset', ev.buf, changed)
+      end,
+    })
+    """
+
+  /// Gets the API channel, verifies the nvim version, returns the channel number.
+  private func getChannelAndVerifyVersion() async throws -> Int32 {
+    let apiInfo = try await self.api.nvimGetApiInfo(errWhenBlocked: false).get()
+    guard apiInfo.count == 2,
+          let channel = apiInfo[0].int32Value,
+          let dict = apiInfo[1].dictionaryValue,
+          let version = dict["version"]?.dictionaryValue,
+          let major = version["major"]?.intValue,
+          let minor = version["minor"]?.intValue,
+          major > kMinMajorVersion || (major == kMinMajorVersion && minor >= kMinMinorVersion)
+    else {
+      throw NvimApi.Error.exception(message: "Error matching API version")
+    }
+    return channel
+  }
+
+  /// Runs the shared autocmd/subscription/source setup that all connection modes need.
+  /// In pipe mode this is called during the vimenter handshake (after the preamble was
+  /// already exec'd by launchNvim). In socket modes it is called directly.
+  private func runCommonNvimSetup(channel: Int32, includePreamble: Bool) async throws {
+    if includePreamble {
+      _ = try await self.api.nvimExecLua(
+        code: Self.preambleLua, args: [], errWhenBlocked: false
+      ).get()
+    }
+
+    _ = try await self.api.nvimExecLua(
+      code: Self.autocmdLua, args: [.int(Int64(channel))], errWhenBlocked: false
+    ).get()
+    dlog.debug("Nvim setup Lua exec'ed (preamble=\(includePreamble))")
+
+    _ = try await self.api
+      .nvimSubscribe(event: NvimView.rpcEventName, expectsReturnValue: false).get()
+
+    for url in self.sourceFileUrls {
+      _ = try await self.api.nvimExecLua(
+        code: "vim.cmd.source(select(1, ...))",
+        args: [.string(url.path)],
+        errWhenBlocked: false
+      ).get()
+    }
+
+    let ginitVimPath = FileManager.default
+      .homeDirectoryForCurrentUser
+      .appendingPathComponent(".config/nvim/ginit.vim").path
+    let ginitLuaPath = FileManager.default
+      .homeDirectoryForCurrentUser
+      .appendingPathComponent(".config/nvim/ginit.lua").path
+    if FileManager.default.fileExists(atPath: ginitLuaPath) {
+      dlog.debug("Source'ing ginit.lua")
+      _ = try await self.api.nvimExecLua(
+        code: "vim.cmd.source(select(1, ...))",
+        args: [.string(ginitLuaPath)],
+        errWhenBlocked: false
+      ).get()
+    } else if FileManager.default.fileExists(atPath: ginitVimPath) {
+      dlog.debug("Source'ing ginit.vim")
+      _ = try await self.api.nvimExecLua(
+        code: "vim.cmd.source(select(1, ...))",
+        args: [.string(ginitVimPath)],
+        errWhenBlocked: false
+      ).get()
+    }
+  }
+
+  /// Attaches the UI to neovim at the given grid size.
+  private func attachUi(width: Int, height: Int) async throws {
+    _ = try await self.api
+      .nvimUiAttach(width: width, height: height, options: [
+        "ext_linegrid": true,
+        "ext_multigrid": false,
+        "ext_tabline": MessagePackValue(self.usesCustomTabBar),
+        "rgb": true,
+      ]).get()
+    dlog.debug("UI attached")
+  }
+
+  // MARK: - Connection Modes
+
+  /// Connect to an already-running neovim instance via Unix socket or TCP.
+  /// Accepts a socket path (e.g. "/tmp/nvim.sock") or host:port (e.g. "localhost:6666").
+  private func connectToRunningNvim(address: String, size: Size) async {
+    dlog.debug("Connecting to running Nvim at \(address)")
+
+    do {
+      try await self.api.run(address: address)
+      try self.apiSync.run(address: address)
+      dlog.debug("Both async and sync APIs connected to \(address)")
+
+      let channel = try await self.getChannelAndVerifyVersion()
+      dlog.debug("Remote Nvim version OK")
+
+      try await self.runCommonNvimSetup(channel: channel, includePreamble: true)
+      try await self.attachUi(width: size.width, height: size.height)
+
+      // In socket/headless mode, nvim has already sourced init.vim before we
+      // connected, so the ColorScheme autocmd fired before our rpcnotify was
+      // registered. Re-applying the active colorscheme causes nvim to re-emit
+      // hl_attr_define + default_colors_set + our ColorScheme rpcnotify so that
+      // VimR's Theme and cell colors are correctly populated.
+      _ = try await self.api.nvimExecLua(
+        code: "vim.cmd.colorscheme(vim.g.colors_name or 'default')",
+        args: [],
+        errWhenBlocked: false
+      ).get()
+
+      self.delegate?.nextEvent(.nvimReady)
+      self.setFrameSize(self.bounds.size)
+    } catch {
+      self.dieWithFatalError(
+        description: "Could not connect to remote Nvim at \(address): \(error)"
+      )
+      return
+    }
+
+    dlog.debug("Connected to running Nvim")
+  }
+
+  /// Launch a local nvim with --listen, then connect via socket (no stdio pipes).
+  private func launchNvimAndConnectViaSocket(_ size: Size) async {
+    dlog.debug("Starting Nvim (socket-launch mode)")
+
+    do {
+      try self.nvimProc.runLocalServerHeadless()
+    } catch {
+      self.dieWithFatalError(description: "Could not launch Nvim: \(error)")
+      return
+    }
+
+    // Give nvim a moment to create the socket
+    let socketPath = self.nvimProc.pipeUrl.path
+    for _ in 0..<50 {
+      if FileManager.default.fileExists(atPath: socketPath) { break }
+      try? await Task.sleep(nanoseconds: 100_000_000) // 100ms
+    }
+
+    await self.connectToRunningNvim(address: socketPath, size: size)
+    dlog.debug("Launched Nvim (socket-launch mode)")
+  }
+
+  /// Handles the blocking "vimenter" rpcrequest during the embedded pipe startup sequence.
+  /// The preamble (GetHiColor etc) was already exec'd by launchNvim(), so we only
+  /// register the autocmds and do subscribe/source/ginit here.
   private func doSetupForVimenterAndSendResponse(forMsgid msgid: UInt32) async {
     do {
-      let apiInfo = try await self.api.nvimGetApiInfo(errWhenBlocked: false).get()
-      guard apiInfo.count == 2,
-            let channel = apiInfo[0].int32Value
-      else {
-        throw NvimApi.Error.exception(message: "Error matching API version")
-      }
-
-      // swiftformat:disable all
-      _ = try await self.api.nvimExec2(src: """
-      autocmd BufWinEnter * call rpcnotify(\(channel), 'autocommand', 'bufwinenter', str2nr(expand('<abuf>')))
-      autocmd BufWinLeave * call rpcnotify(\(channel), 'autocommand', 'bufwinleave', str2nr(expand('<abuf>')))
-      autocmd TabEnter * call rpcnotify(\(channel), 'autocommand', 'tabenter', str2nr(expand('<abuf>')))
-      autocmd BufWritePost * call rpcnotify(\(channel), 'autocommand', 'bufwritepost', str2nr(expand('<abuf>')))
-      autocmd BufEnter * call rpcnotify(\(channel), 'autocommand', 'bufenter', str2nr(expand('<abuf>')))
-      autocmd DirChanged * call rpcnotify(\( channel), 'autocommand', 'dirchanged', expand('<afile>'))
-      autocmd BufModifiedSet * call rpcnotify(\(channel), 'autocommand', 'bufmodifiedset', str2nr(expand('<abuf>')), getbufinfo(str2nr(expand('<abuf>')))[0].changed)
-      """, opts: [:], errWhenBlocked: false).get()
-      // swiftformat:enable all
-
-      _ = try await self.api
-        .nvimSubscribe(event: NvimView.rpcEventName, expectsReturnValue: false).get()
-
-      for url in self.sourceFileUrls {
-        _ = try await self.api
-          .nvimExec2(
-            src: "source \(url.shellEscapedPath)",
-            opts: [:],
-            errWhenBlocked: false
-          ).get()
-      }
+      let channel = try await self.getChannelAndVerifyVersion()
+      try await self.runCommonNvimSetup(channel: channel, includePreamble: false)
       _ = try await self.api.sendResponse(.nilResponse(msgid)).get()
-
-      let ginitPath = FileManager.default
-        .homeDirectoryForCurrentUser
-        .appendingPathComponent(".config/nvim/ginit.vim").path
-      if FileManager.default.fileExists(atPath: ginitPath) {
-        dlog.debug("Source'ing ginit.vim")
-        _ = try await self.api.nvimCommand(command: "source \(ginitPath.shellEscapedPath)").get()
-      }
     } catch {
       self.dieWithFatalError(description: "Could not set up vimenter event: \(error)")
     }
   }
 
+  /// Classic mode: spawn nvim with --embed, communicate via stdio pipes.
   private func launchNvim(_ size: Size) async {
     dlog.debug("Starting Nvim")
 
@@ -432,51 +624,36 @@ public final class NvimView: NSView,
       // When we call nvim_command("autocmd VimEnter * call rpcrequest(1, 'vimenter')")
       // Neovim will send us a vimenter request and enter a blocking state.
       // We do some autocmd setup and send a response to exit the blocking state in
-      // NvimView.swift
+      // the vimenter handler in runBridge().
       try await self.api.run(inPipe: inPipe, outPipe: outPipe, errorPipe: errorPipe)
-      let apiInfo = try await self.api.nvimGetApiInfo(errWhenBlocked: false).get()
-      guard apiInfo.count == 2,
-            let channel = apiInfo[0].int32Value,
-            let dict = apiInfo[1].dictionaryValue,
-            let version = dict["version"]?.dictionaryValue,
-            let major = version["major"]?.intValue,
-            let minor = version["minor"]?.intValue,
-            major > kMinMajorVersion || (major == kMinMajorVersion && minor >= kMinMinorVersion)
-      else {
-        throw NvimApi.Error.exception(message: "Error matching API version")
-      }
-
+      let channel = try await self.getChannelAndVerifyVersion()
       dlog.debug("Version fine")
 
-      // swiftformat:disable all
-      let vimscript = """
-        function! GetHiColor(hlID, component)
-          let color = synIDattr(synIDtrans(hlID(a:hlID)), a:component)
-          if empty(color)
-            return -1
-          else
-            return str2nr(color[1:], 16)
-          endif
-        endfunction
-        let g:gui_vimr = 1
-        autocmd VimLeave * call rpcnotify(\(channel), 'autocommand', 'vimleave')
-        autocmd VimEnter * call rpcnotify(\(channel), 'autocommand', 'vimenter')
-        autocmd ColorScheme * call rpcnotify(\(channel), 'autocommand', 'colorscheme', GetHiColor('Normal', 'fg'), GetHiColor('Normal', 'bg'), GetHiColor('Visual', 'fg'), GetHiColor('Visual', 'bg'), GetHiColor('Directory', 'fg'), GetHiColor('TablineFill', 'bg'), GetHiColor('TablineFill', 'fg'), GetHiColor('Tabline', 'bg'), GetHiColor('Tabline', 'fg'), GetHiColor('TablineSel', 'bg'), GetHiColor('TablineSel', 'fg'))
-        autocmd VimEnter * call rpcrequest(\(channel), 'vimenter')
-        """
-      // swiftformat:enable all
+      // Only the preamble and VimEnter hooks here. The full autocmd set is
+      // registered later in doSetupForVimenterAndSendResponse() when the
+      // blocking rpcrequest arrives.
+      _ = try await self.api.nvimExecLua(
+        code: Self.preambleLua, args: [], errWhenBlocked: false
+      ).get()
+      _ = try await self.api.nvimExecLua(
+        code: """
+          local ch = select(1, ...)
+          local augroup = vim.api.nvim_create_augroup('VimRBridge', { clear = true })
+          vim.api.nvim_create_autocmd('VimEnter', {
+            group = augroup, once = true,
+            callback = function() vim.rpcnotify(ch, 'autocommand', 'vimenter') end,
+          })
+          vim.api.nvim_create_autocmd('VimEnter', {
+            group = augroup, once = true,
+            callback = function() vim.rpcrequest(ch, 'vimenter') end,
+          })
+          """,
+        args: [.int(Int64(channel))],
+        errWhenBlocked: false
+      ).get()
+      dlog.debug("Initial Lua exec'ed")
 
-      _ = try await self.api.nvimExec2(src: vimscript, opts: [:], errWhenBlocked: false).get()
-      dlog.debug("Initial script exec'ed")
-
-      _ = try await self.api
-        .nvimUiAttach(width: size.width, height: size.height, options: [
-          "ext_linegrid": true,
-          "ext_multigrid": false,
-          "ext_tabline": MessagePackValue(self.usesCustomTabBar),
-          "rgb": true,
-        ]).get()
-      dlog.debug("UI attached")
+      try await self.attachUi(width: size.width, height: size.height)
     } catch {
       self.dieWithFatalError(
         description: "Could not attach UI and exec initial setup script: \(error)"

--- a/VimR/VimR/AdvancedPrefReducer.swift
+++ b/VimR/VimR/AdvancedPrefReducer.swift
@@ -26,6 +26,9 @@ final class AdvancedPrefReducer: ReducerType {
 
     case let .setNvimAppName(value):
       state.nvimAppName = value
+
+    case let .setConnectionMode(value):
+      state.mainWindowTemplate.connectionMode = value
     }
 
     return ReduceTuple(state: state, action: tuple.action, modified: true)

--- a/VimR/VimR/AdvencedPref.swift
+++ b/VimR/VimR/AdvencedPref.swift
@@ -14,6 +14,7 @@ final class AdvancedPref: PrefPane, UiComponent, NSTextFieldDelegate {
     case setUseSnapshotUpdate(Bool)
     case setNvimBinary(String)
     case setNvimAppName(String)
+    case setConnectionMode(MainWindow.NvimConnectionMode)
   }
 
   let uuid = UUID()
@@ -33,6 +34,7 @@ final class AdvancedPref: PrefPane, UiComponent, NSTextFieldDelegate {
     self.useSnapshotUpdate = state.useSnapshotUpdate
     self.nvimBinary = state.mainWindowTemplate.nvimBinary
     self.nvimAppName = state.nvimAppName
+    self.connectionMode = state.mainWindowTemplate.connectionMode
 
     super.init(frame: .zero)
 
@@ -44,11 +46,13 @@ final class AdvancedPref: PrefPane, UiComponent, NSTextFieldDelegate {
         || self.nvimBinary != state.mainWindowTemplate.nvimBinary
         || self.nvimAppName != state.nvimAppName
         || self.useSnapshotUpdate != state.useSnapshotUpdate
+        || self.connectionMode != state.mainWindowTemplate.connectionMode
       {
         self.useInteractiveZsh = state.mainWindowTemplate.useInteractiveZsh
         self.nvimBinary = state.mainWindowTemplate.nvimBinary
         self.nvimAppName = state.nvimAppName
         self.useSnapshotUpdate = state.useSnapshotUpdate
+        self.connectionMode = state.mainWindowTemplate.connectionMode
 
         self.updateViews()
       }
@@ -61,11 +65,13 @@ final class AdvancedPref: PrefPane, UiComponent, NSTextFieldDelegate {
   private var useSnapshotUpdate: Bool
   private var nvimBinary: String = ""
   private var nvimAppName: String = ""
+  private var connectionMode: MainWindow.NvimConnectionMode
 
   private let useInteractiveZshCheckbox = NSButton(forAutoLayout: ())
   private let useSnapshotUpdateCheckbox = NSButton(forAutoLayout: ())
   private let nvimBinaryField = NSTextField(forAutoLayout: ())
   private let nvimAppNameField = NSTextField(forAutoLayout: ())
+  private let connectionModePopup = NSPopUpButton(forAutoLayout: ())
 
   @available(*, unavailable)
   required init?(coder _: NSCoder) {
@@ -82,6 +88,10 @@ final class AdvancedPref: PrefPane, UiComponent, NSTextFieldDelegate {
     self.useInteractiveZshCheckbox.boolState = self.useInteractiveZsh
     self.nvimBinaryField.stringValue = self.nvimBinary
     self.nvimAppNameField.stringValue = self.nvimAppName
+
+    let modeIndex = MainWindow.NvimConnectionMode.allCases
+      .firstIndex(of: self.connectionMode) ?? 0
+    self.connectionModePopup.selectItem(at: modeIndex)
   }
 
   private func addViews() {
@@ -122,6 +132,21 @@ final class AdvancedPref: PrefPane, UiComponent, NSTextFieldDelegate {
     When set, VimR will set the `NVIM_APPNAME` environment variable to this value by default.
     """#)
 
+    let connectionModeTitle = self.titleTextField(title: "Connection Mode:")
+    let connectionModePopup = self.connectionModePopup
+    connectionModePopup.removeAllItems()
+    connectionModePopup.addItems(withTitles: [
+      "Embedded (stdio pipe)",
+      "Embedded (socket)",
+    ])
+    connectionModePopup.target = self
+    connectionModePopup.action = #selector(AdvancedPref.connectionModeAction(_:))
+    let connectionModeInfo = self.infoTextField(markdown: #"""
+    **Embedded (stdio pipe)**: Classic mode. VimR launches nvim and communicates via stdin/stdout.\
+    **Embedded (socket)**: VimR launches nvim with `--listen` and connects via Unix socket.\
+    Socket mode enables future support for attaching to running servers.
+    """#)
+
     self.addSubview(paneTitle)
 
     self.addSubview(useSnapshotUpdate)
@@ -133,6 +158,9 @@ final class AdvancedPref: PrefPane, UiComponent, NSTextFieldDelegate {
     self.addSubview(nvimAppNameTitle)
     self.addSubview(nvimAppNameField)
     self.addSubview(nvimAppNameInfo)
+    self.addSubview(connectionModeTitle)
+    self.addSubview(connectionModePopup)
+    self.addSubview(connectionModeInfo)
 
     paneTitle.autoPinEdge(toSuperviewEdge: .top, withInset: 18)
     paneTitle.autoPinEdge(toSuperviewEdge: .left, withInset: 18)
@@ -190,6 +218,15 @@ final class AdvancedPref: PrefPane, UiComponent, NSTextFieldDelegate {
 
     nvimAppNameInfo.autoPinEdge(.top, to: .bottom, of: nvimAppNameField, withOffset: 5)
     nvimAppNameInfo.autoPinEdge(.left, to: .right, of: nvimAppNameTitle, withOffset: 5)
+
+    connectionModeTitle.autoPinEdge(.top, to: .bottom, of: nvimAppNameInfo, withOffset: 18)
+    connectionModeTitle.autoPinEdge(.right, to: .right, of: nvimAppNameTitle)
+
+    connectionModePopup.autoAlignAxis(.baseline, toSameAxisOf: connectionModeTitle)
+    connectionModePopup.autoPinEdge(.left, to: .right, of: connectionModeTitle, withOffset: 5)
+
+    connectionModeInfo.autoPinEdge(.top, to: .bottom, of: connectionModePopup, withOffset: 5)
+    connectionModeInfo.autoPinEdge(.left, to: .left, of: connectionModePopup)
   }
 }
 
@@ -212,5 +249,12 @@ extension AdvancedPref {
   func nvimAppNameFieldAction() {
     let newNvimAppName = self.nvimAppNameField.stringValue
     self.emit(.setNvimAppName(newNvimAppName))
+  }
+
+  @objc func connectionModeAction(_ sender: NSPopUpButton) {
+    let modes = MainWindow.NvimConnectionMode.allCases
+    let index = sender.indexOfSelectedItem
+    guard index >= 0, index < modes.count else { return }
+    self.emit(.setConnectionMode(modes[index]))
   }
 }

--- a/VimR/VimR/AppDelegate.swift
+++ b/VimR/VimR/AppDelegate.swift
@@ -37,6 +37,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     var nvimArgs: [String]?
     var additionalEnvs: [String: String]
     var line: Int?
+    /// When set, connect to this running neovim socket instead of launching a new one.
+    var remoteSocketPath: String?
   }
 
   enum Action {
@@ -233,6 +235,20 @@ extension AppDelegate {
     self.launching = false
 
     self.updaterController.startUpdater()
+
+    // Add "Connect to Running Neovim..." menu item to File menu
+    if let fileMenu = NSApp.mainMenu?.items.first(where: { $0.title == "File" })?.submenu {
+      let connectItem = NSMenuItem(
+        title: "Connect to Running Neovim...",
+        action: #selector(AppDelegate.connectToRunningNvim(_:)),
+        keyEquivalent: ""
+      )
+      connectItem.keyEquivalentModifierMask = [.command, .shift, .option]
+      connectItem.keyEquivalent = "n"
+      // Insert after "New with Custom Config Location" (index 1), or at position 2
+      let insertIndex = min(2, fileMenu.items.count)
+      fileMenu.insertItem(connectItem, at: insertIndex)
+    }
 
     #if DEBUG
     NSApp.mainMenu?.items.first { $0.identifier == debugMenuItemIdentifier }?.isHidden = false
@@ -461,6 +477,23 @@ extension AppDelegate {
         line: line
       )
       self.emit(.newMainWindow(config: config))
+
+    case .connectRemote:
+      guard let remoteAddress = self.queryParam(
+        remoteAddressPrefix,
+        from: rawParams,
+        transforming: identity
+      ).first else { return }
+      let config = OpenConfig(
+        urls: [],
+        cwd: cwd,
+        cliPipePath: pipePath,
+        nvimArgs: nil,
+        additionalEnvs: [:],
+        line: nil,
+        remoteSocketPath: remoteAddress
+      )
+      self.emit(.newMainWindow(config: config))
     }
   }
 
@@ -538,6 +571,34 @@ extension AppDelegate {
     self.stopCustomConfigWindow()
   }
 
+  /// Shows a dialog for the user to enter a socket path, then opens a new window
+  /// connected to that running neovim instance.
+  @IBAction func connectToRunningNvim(_: Any?) {
+    let alert = NSAlert()
+    alert.messageText = "Connect to Running Neovim"
+    alert.informativeText = "Enter the Unix socket path of a running neovim instance.\n"
+      + "Start neovim with: nvim --listen /tmp/nvim.sock --headless"
+    alert.alertStyle = .informational
+    alert.addButton(withTitle: "Connect")
+    alert.addButton(withTitle: "Cancel")
+
+    let input = NSTextField(frame: NSRect(x: 0, y: 0, width: 340, height: 24))
+    input.placeholderString = "/tmp/nvim.sock"
+    alert.accessoryView = input
+
+    let response = alert.runModal()
+    guard response == .alertFirstButtonReturn else { return }
+
+    let socketPath = input.stringValue.trimmingCharacters(in: .whitespaces)
+    guard !socketPath.isEmpty else { return }
+
+    let config = OpenConfig(
+      urls: [], cwd: FileUtils.userHomeUrl, cliPipePath: nil, nvimArgs: nil,
+      additionalEnvs: [:], line: nil, remoteSocketPath: socketPath
+    )
+    self.emit(.newMainWindow(config: config))
+  }
+
   @IBAction func openInNewWindow(_ sender: Any?) { self.openDocument(sender) }
 
   @IBAction func showPrefWindow(_: Any?) { self.emit(.preferences) }
@@ -560,6 +621,11 @@ extension AppDelegate {
       self.emit(.newMainWindow(config: config))
     }
   }
+
+  /// Open a new main window. Called from RPC event handlers in other files.
+  func openNewMainWindow(config: OpenConfig) {
+    self.emit(.newMainWindow(config: config))
+  }
 }
 
 // MARK: - NSUserNotificationCenterDelegate
@@ -578,6 +644,7 @@ private enum VimRUrlAction: String {
   case newWindow = "open-in-new-window"
   case separateWindows = "open-in-separate-windows"
   case nvim
+  case connectRemote = "connect-to-remote"
 }
 
 // Keep in sync with QueryParamKey in the `vimr` Python script.
@@ -588,3 +655,4 @@ private let pipePathPrefix = "pipe-path="
 private let waitPrefix = "wait="
 private let envPathPrefix = "env-path="
 private let linePrefix = "line="
+private let remoteAddressPrefix = "remote-address="

--- a/VimR/VimR/AppDelegate.swift
+++ b/VimR/VimR/AppDelegate.swift
@@ -576,14 +576,15 @@ extension AppDelegate {
   @IBAction func connectToRunningNvim(_: Any?) {
     let alert = NSAlert()
     alert.messageText = "Connect to Running Neovim"
-    alert.informativeText = "Enter the Unix socket path of a running neovim instance.\n"
-      + "Start neovim with: nvim --listen /tmp/nvim.sock --headless"
+    alert.informativeText = "Enter the Unix socket path or TCP address (host:port) of a running neovim instance.\n"
+      + "Start neovim with: nvim --listen /tmp/nvim.sock --headless\n"
+      + "or for TCP: nvim --listen 0.0.0.0:6666 --headless"
     alert.alertStyle = .informational
     alert.addButton(withTitle: "Connect")
     alert.addButton(withTitle: "Cancel")
 
     let input = NSTextField(frame: NSRect(x: 0, y: 0, width: 340, height: 24))
-    input.placeholderString = "/tmp/nvim.sock"
+    input.placeholderString = "/tmp/nvim.sock  or  192.168.1.10:6666"
     alert.accessoryView = input
 
     let response = alert.runModal()

--- a/VimR/VimR/AppDelegate.swift
+++ b/VimR/VimR/AppDelegate.swift
@@ -292,6 +292,7 @@ extension AppDelegate {
         alert.alertStyle = .informational
         alert.runModal()
 
+        NSApplication.shared.reply(toApplicationShouldTerminate: false)
         return
       }
 
@@ -313,6 +314,7 @@ extension AppDelegate {
           return
         }
 
+        NSApplication.shared.reply(toApplicationShouldTerminate: false)
         return
       }
 

--- a/VimR/VimR/AppDelegateReducer.swift
+++ b/VimR/VimR/AppDelegateReducer.swift
@@ -76,6 +76,7 @@ final class AppDelegateReducer: ReducerType {
     if let line = config.line {
       mainWindow.goToLineFromCli = Marked(line)
     }
+    mainWindow.remoteSocketPath = config.remoteSocketPath
 
     return mainWindow
   }

--- a/VimR/VimR/FileBrowser.swift
+++ b/VimR/VimR/FileBrowser.swift
@@ -31,6 +31,7 @@ final class FileBrowser: NSView, UiComponent {
     self.mainWinUuid = state.uuid
 
     self.cwd = state.cwd
+    self.isRemote = state.remoteSocketPath != nil
 
     self.fileView = FileOutlineView(context: context, state: state)
 
@@ -70,6 +71,7 @@ final class FileBrowser: NSView, UiComponent {
   private let emit: (UuidAction<Action>) -> Void
 
   private let mainWinUuid: UUID
+  private let isRemote: Bool
 
   private var currentBufferUrl: URL?
 
@@ -82,12 +84,25 @@ final class FileBrowser: NSView, UiComponent {
   required init?(coder _: NSCoder) { fatalError("init(coder:) has not been implemented") }
 
   private func addViews() {
-    let scrollView = NSScrollView.standardScrollView()
-    scrollView.borderType = .noBorder
-    scrollView.documentView = self.fileView
+    if self.isRemote {
+      let label = NSTextField(labelWithString: "File browser is not available\nfor remote connections.")
+      label.alignment = .center
+      label.textColor = .secondaryLabelColor
+      label.font = NSFont.systemFont(ofSize: NSFont.smallSystemFontSize)
+      label.isSelectable = false
 
-    self.addSubview(scrollView)
-    scrollView.autoPinEdgesToSuperviewEdges()
+      self.addSubview(label)
+      label.autoCenterInSuperview()
+      label.autoPinEdge(toSuperviewEdge: .left, withInset: 16)
+      label.autoPinEdge(toSuperviewEdge: .right, withInset: 16)
+    } else {
+      let scrollView = NSScrollView.standardScrollView()
+      scrollView.borderType = .noBorder
+      scrollView.documentView = self.fileView
+
+      self.addSubview(scrollView)
+      scrollView.autoPinEdgesToSuperviewEdges()
+    }
   }
 }
 

--- a/VimR/VimR/MainWindow+Actions.swift
+++ b/VimR/VimR/MainWindow+Actions.swift
@@ -86,6 +86,30 @@ extension MainWindow {
       guard let characterspacing = params[0].doubleValue else { return }
 
       self.emit(self.uuidAction(for: .setCharacterspacing(characterspacing)))
+
+    case .openNewWindow:
+      guard let appDelegate = NSApp.delegate as? AppDelegate else { return }
+      let config = AppDelegate.OpenConfig(
+        urls: [],
+        cwd: self.neoVimView.cwd,
+        cliPipePath: nil,
+        nvimArgs: nil,
+        additionalEnvs: [:]
+      )
+      appDelegate.openNewMainWindow(config: config)
+
+    case .connectToRemote:
+      guard params.count == 1, let address = params[0].stringValue else { return }
+      guard let appDelegate = NSApp.delegate as? AppDelegate else { return }
+      let config = AppDelegate.OpenConfig(
+        urls: [],
+        cwd: self.neoVimView.cwd,
+        cliPipePath: nil,
+        nvimArgs: nil,
+        additionalEnvs: [:],
+        remoteSocketPath: address
+      )
+      appDelegate.openNewMainWindow(config: config)
     }
   }
 

--- a/VimR/VimR/MainWindow+Actions.swift
+++ b/VimR/VimR/MainWindow+Actions.swift
@@ -100,6 +100,8 @@ extension MainWindow {
 
     case .connectToRemote:
       guard params.count == 1, let address = params[0].stringValue else { return }
+      let trimmedAddress = address.trimmingCharacters(in: .whitespaces)
+      guard !trimmedAddress.isEmpty else { return }
       guard let appDelegate = NSApp.delegate as? AppDelegate else { return }
       let config = AppDelegate.OpenConfig(
         urls: [],
@@ -107,7 +109,7 @@ extension MainWindow {
         cliPipePath: nil,
         nvimArgs: nil,
         additionalEnvs: [:],
-        remoteSocketPath: address
+        remoteSocketPath: trimmedAddress
       )
       appDelegate.openNewMainWindow(config: config)
     }

--- a/VimR/VimR/MainWindow+Actions.swift
+++ b/VimR/VimR/MainWindow+Actions.swift
@@ -182,7 +182,6 @@ extension MainWindow {
   }
 
   @IBAction func closeWindow(_: Any?) {
-    self.closeWindow = true
     self.window.performClose(nil)
   }
 

--- a/VimR/VimR/MainWindow+Delegates.swift
+++ b/VimR/VimR/MainWindow+Delegates.swift
@@ -103,7 +103,9 @@ extension MainWindow {
         + reason
     alert.alertStyle = .critical
     alert.beginSheetModal(for: self.window) { _ in
-      self.windowController.close()
+      // Route through neoVimStopped so isClosing is set, the CLI pipe is closed,
+      // and the Redux .close action is emitted — same as the normal close path.
+      self.neoVimStopped()
     }
   }
 
@@ -200,9 +202,6 @@ extension MainWindow {
   }
 
   func windowShouldClose(_: NSWindow) -> Bool {
-    defer { self.closeWindow = false }
-    let closeWindow = self.closeWindow
-
     Task {
       if await self.neoVimView.isBlocked() {
         let alert = NSAlert()
@@ -215,22 +214,6 @@ extension MainWindow {
       // Connected to an external nvim — just detach, never send :q/:qa!
       if self.neoVimView.isAttachedToRunningNvim {
         await self.neoVimView.stop()
-        return
-      }
-
-      if closeWindow {
-        if await self.neoVimView.hasDirtyBuffers() {
-          self.discardCloseActionAlert().beginSheetModal(for: self.window) { response in
-            if response == .alertSecondButtonReturn {
-              Task {
-                await self.neoVimView.quitNeoVimWithoutSaving()
-              }
-            }
-          }
-        } else {
-          await self.neoVimView.quitNeoVimWithoutSaving()
-        }
-
         return
       }
 

--- a/VimR/VimR/MainWindow+Delegates.swift
+++ b/VimR/VimR/MainWindow+Delegates.swift
@@ -212,6 +212,12 @@ extension MainWindow {
         return
       }
 
+      // Connected to an external nvim — just detach, never send :q/:qa!
+      if self.neoVimView.isAttachedToRunningNvim {
+        await self.neoVimView.stop()
+        return
+      }
+
       if closeWindow {
         if await self.neoVimView.hasDirtyBuffers() {
           self.discardCloseActionAlert().beginSheetModal(for: self.window) { response in

--- a/VimR/VimR/MainWindow.swift
+++ b/VimR/VimR/MainWindow.swift
@@ -56,7 +56,6 @@ final class MainWindow: NSObject,
   var repIcon: NSButton?
   var titleView: NSTextField?
 
-  var closeWindow = false
   var isClosing = false
   let cliPipePath: String?
 

--- a/VimR/VimR/MainWindow.swift
+++ b/VimR/VimR/MainWindow.swift
@@ -84,7 +84,9 @@ final class MainWindow: NSObject,
       nvimBinary: state.nvimBinary,
       nvimArgs: state.nvimArgs,
       additionalEnvs: state.additionalEnvs,
-      sourceFiles: sourceFileUrls
+      sourceFiles: sourceFileUrls,
+      remoteSocketPath: state.remoteSocketPath,
+      useSocketConnection: state.connectionMode == .embeddedSocket
     )
     self.neoVimView = NvimView(
       frame: .init(x: 0, y: 0, width: 640, height: 480),

--- a/VimR/VimR/RpcEvents.swift
+++ b/VimR/VimR/RpcEvents.swift
@@ -21,4 +21,11 @@ enum RpcEvent: String, CaseIterable {
   case revealCurrentBufferInFileBrowser =
     "com.qvacua.vimr.rpc-events.reveal-current-buffer-in-file-browser"
   case refreshFileBrowser = "com.qvacua.vimr.rpc-events.refresh-file-browser"
+
+  /// Open a new blank VimR window with VimR's own nvim process.
+  case openNewWindow = "com.qvacua.vimr.rpc-events.open-new-window"
+
+  /// Open a new VimR window connected to an already-running neovim at the given address.
+  /// Pass the socket path or host:port as the first RPC argument.
+  case connectToRemote = "com.qvacua.vimr.rpc-events.connect-to-remote"
 }

--- a/VimR/VimR/States.swift
+++ b/VimR/VimR/States.swift
@@ -267,6 +267,14 @@ struct AppearanceState: Codable, Sendable {
 }
 
 extension MainWindow {
+  /// How VimR connects to neovim.
+  enum NvimConnectionMode: String, Codable, CaseIterable, Sendable {
+    /// Classic mode: spawn nvim with --embed, communicate via stdio pipes.
+    case embeddedPipe = "embedded-pipe"
+    /// Launch nvim with --listen, then connect via Unix domain socket.
+    case embeddedSocket = "embedded-socket"
+  }
+
   struct State: Codable, Sendable {
     static let `default` = State(
       isAllToolsVisible: true,
@@ -327,6 +335,10 @@ extension MainWindow {
     var nvimArgs: [String]?
     var cliPipePath: String?
     var additionalEnvs: [String: String] = [:]
+    var connectionMode = NvimConnectionMode.embeddedPipe
+
+    /// Set at window creation time for "Connect to Running Neovim" (transient, not serialized).
+    var remoteSocketPath: String?
 
     var usesVcsIgnores = true
 
@@ -357,6 +369,7 @@ extension MainWindow {
 
       case useInteractiveZsh = "use-interactive-zsh"
       case nvimBinary = "nvim-binary"
+      case connectionMode = "connection-mode"
 
       case useLiveResize = "use-live-resize"
       case isShowHidden = "is-show-hidden"
@@ -384,6 +397,10 @@ extension MainWindow {
       )
       self.nvimBinary = try container.decodeIfPresent(String.self, forKey: .nvimBinary) ?? State
         .default.nvimBinary
+      self.connectionMode = try container.decode(
+        forKey: .connectionMode,
+        default: State.default.connectionMode
+      )
 
       if let frameRawValue = try container.decodeIfPresent(String.self, forKey: .frame) {
         self.frame = NSRectFromString(frameRawValue)
@@ -462,6 +479,7 @@ extension MainWindow {
       try container.encode(self.isRightOptionMeta, forKey: .isRightOptionMeta)
       try container.encode(self.useInteractiveZsh, forKey: .useInteractiveZsh)
       try container.encode(self.nvimBinary, forKey: .nvimBinary)
+      try container.encode(self.connectionMode, forKey: .connectionMode)
       try container.encode(self.fileBrowserShowHidden, forKey: .isShowHidden)
 
       // See [1]

--- a/VimR/VimR/UiRoot.swift
+++ b/VimR/VimR/UiRoot.swift
@@ -28,6 +28,7 @@ final class UiRoot: UiComponent {
     context.subscribe(uuid: self.uuid) { state in
       let uuidsInState = Set(state.mainWindows.keys)
 
+      // Open any new windows that appeared in state.
       uuidsInState
         .subtracting(self.mainWindows.keys)
         .compactMap { state.mainWindows[$0] }
@@ -36,17 +37,9 @@ final class UiRoot: UiComponent {
           mainWindow.show()
         }
 
-      if self.mainWindows.isEmpty {
-        // We exit here if there are no main windows open.
-        // Otherwise, when hide/quit after last main window is active,
-        // you have to be really quick to open a new window
-        // when re-activating VimR w/o automatic new main window.
-        return
-      }
-
-      self.mainWindows.keys
-        .filter { !uuidsInState.contains($0) }
-        .forEach(self.removeMainWindow)
+      // Remove windows that are no longer in state.
+      let uuidsToRemove = self.mainWindows.keys.filter { !uuidsInState.contains($0) }
+      uuidsToRemove.forEach(self.removeMainWindow)
 
       if self.activateAsciiImInInsertMode != state.activateAsciiImInNormalMode {
         self.activateAsciiImInInsertMode = state.activateAsciiImInNormalMode
@@ -54,7 +47,12 @@ final class UiRoot: UiComponent {
           .forEach { $0.activateAsciiImInInsertMode = self.activateAsciiImInInsertMode }
       }
 
-      guard self.mainWindows.isEmpty else { return }
+      // Only trigger the after-last-window action if we actually removed something
+      // in this update and the result is that no windows remain. Guarding on
+      // `!uuidsToRemove.isEmpty` prevents a rapid second state update (where
+      // self.mainWindows is already empty at entry) from erroneously skipping or
+      // double-firing the quit/hide action.
+      guard !uuidsToRemove.isEmpty, self.mainWindows.isEmpty else { return }
 
       switch state.afterLastWindowAction {
       case .doNothing: return

--- a/VimR/VimR/com.qvacua.VimR.vim
+++ b/VimR/VimR/com.qvacua.VimR.vim
@@ -56,3 +56,16 @@ function! s:VimRSetCharacterspacing(characterspacing) abort
 call rpcnotify(0, 'com.qvacua.NvimView', 'set-characterspacing', a:characterspacing)
 endfunction
 command! -nargs=1 VimRSetCharacterspacing call s:VimRSetCharacterspacing(<args>)
+
+" Open a new blank VimR window with VimR's own nvim process.
+function! s:VimRNewWindow() abort
+	call rpcnotify(0, 'com.qvacua.NvimView', 'open-new-window')
+endfunction
+command! -nargs=0 VimRNewWindow call s:VimRNewWindow()
+
+" Open a new VimR window connected to an already-running neovim at ADDRESS.
+" ADDRESS is a Unix socket path or host:port (e.g. /tmp/nvim.sock or 127.0.0.1:6666).
+function! s:VimRConnectToRemote(address) abort
+	call rpcnotify(0, 'com.qvacua.NvimView', 'connect-to-remote', a:address)
+endfunction
+command! -nargs=1 VimRConnectToRemote call s:VimRConnectToRemote(<f-args>)

--- a/VimR/VimR/vimr
+++ b/VimR/VimR/vimr
@@ -16,6 +16,7 @@ class Action(Enum):
     NEW_WINDOW = "open-in-new-window"
     SEPARATE_WINDOWS = "open-in-separate-windows"
     NVIM = "nvim"
+    CONNECT_REMOTE = "connect-to-remote"
 
 
 class QueryParamKey(Enum):
@@ -26,6 +27,7 @@ class QueryParamKey(Enum):
     NVIM_ARGS = "nvim-args"
     WAIT = "wait"
     LINE = "line"
+    REMOTE_ADDRESS = "remote-address"
 
 
 def wait_for_ui_to_close(pipe_path):
@@ -58,6 +60,12 @@ def vimr_nvim(other_args, nvim_args, query_params):
         query_params[QueryParamKey.NVIM_ARGS.value] = nvim_args
 
     call_open(Action.NVIM, query_params, other_args)
+
+
+def vimr_remote(args, query_params):
+    query_params[QueryParamKey.REMOTE_ADDRESS.value] = args.remote
+    query_params[QueryParamKey.CWD.value] = os.getcwd()
+    call_open(Action.CONNECT_REMOTE, query_params, args)
 
 
 def vimr(action, args, query_params):
@@ -114,6 +122,9 @@ def main(args):
         other_args, nvim_args = nvim_parser.parse_known_args()
         vimr_nvim(other_args, nvim_args, query_params)
 
+    elif args.remote:
+        vimr_remote(args, query_params)
+
     else:
         if not args.file:
             action = Action.ACTIVATE
@@ -152,6 +163,11 @@ The working directory will be set to the current directory.
                         action="store_true",
                         help="All arguments except --cur-env, --line, --dry-run and --wait will be passed "
                              "over to the (new) nvim instance in a new UI window.")
+    parser.add_argument("--remote",
+                        action="store",
+                        metavar="ADDRESS",
+                        help="Open a new VimR window connected to the already-running neovim at ADDRESS "
+                             "(Unix socket path or host:port). Cannot be combined with file arguments.")
 
     group = parser.add_mutually_exclusive_group()
     # no option => Open files in tabs in the front most window.


### PR DESCRIPTION
This adds the option (via settings) to use socket connections rather than pipes Also to connect to a nvim server
* Use bluesocket to implement the socket communication
* refactor setup machinery to be lua and reused in both contexts

- add vimr cli support for connecting to a remote
- add VimRNewWindow and VimrRConnectToRemote commands
- allow 3 connection modes (stdio / socket to launched nvim / connect to remote)
- Ensures we see colorscheme for remote connections by reasserting it
- fixes guifont issues with comma separated fallbacks