### PR TITLE
Add "New Window" option on macOS Dock icon

### DIFF
--- a/VimR/VimR/AppDelegate.swift
+++ b/VimR/VimR/AppDelegate.swift
@@ -327,6 +327,18 @@ extension AppDelegate {
     return .terminateLater
   }
 
+  func applicationDockMenu(_: NSApplication) -> NSMenu? {
+    let menu = NSMenu()
+    let newWindowItem = NSMenuItem(
+      title: "New Window",
+      action: #selector(AppDelegate.newDocument(_:)),
+      keyEquivalent: ""
+    )
+    newWindowItem.target = self
+    menu.addItem(newWindowItem)
+    return menu
+  }
+
   // For drag & dropping files on the App icon.
   func application(_ sender: NSApplication, openFiles filenames: [String]) {
     let urls = filenames.map { URL(fileURLWithPath: $0) }


### PR DESCRIPTION
Adds a "New Window" option when right-clicking the macOS Dock icon.

---

Most applications that deal with documents or editing in general offer this option.

<img width="400" src="https://github.com/user-attachments/assets/4d6e29ef-b409-4e11-97b8-f6798b86f55e" />
