### PR TITLE
Bugfix MsgpackRpc error handler

### DIFF
--- a/NvimApi/Sources/NvimApi/MsgpackRpc.swift
+++ b/NvimApi/Sources/NvimApi/MsgpackRpc.swift
@@ -408,7 +408,7 @@ public actor MsgpackRpc {
         (value, subdata) = try unpack(subdata, compatibility: false)
         values.append(consume value)
       } catch MessagePackError.insufficientData {
-        remainderData = data
+        remainderData = subdata
         break
       }
     }


### PR DESCRIPTION
If the error handler is called it can set `remainderData` to the original `data` meaning we re-process some parts of the data that have already been processed, potentially leading to out of bounds writes to cell arrays via e.g. `recomputeFlatIndices` and `updateNu`.

This is attempt to fix #1164. I have been running a custom build with this fix for several weeks, and have not encountered that bug once since then, whereas I was encountering it at least daily prior to this fix. I have also not encountered any other crashes/bugs while using a build with this fix. 

I didn't try to add tests for this code since there do not seem to be tests for the surrounding code yet, and I wasn't sure about your goals/expectations for such testing. But I am happy to try to add some test coverage if you want to suggest an approach to doing so, and/or point to some other code that demonstrates the (rough or precise) conventions you'd like me to follow. 